### PR TITLE
port BoardHandler implementation from wip-board-handler

### DIFF
--- a/src/main/java/domain/model/GameModel.java
+++ b/src/main/java/domain/model/GameModel.java
@@ -161,7 +161,7 @@ public class GameModel {
         for (Resource r : EnumSet.of(Resource.BRICK, Resource.LUMBER, Resource.WOOL, Resource.GRAIN)) {
             checkPlayerOwnsEnoughResources(currentPlayerColor, r, 1);
         }
-        board.buildSettlement(currentPlayerColor, nodeID);
+        board.buildSettlement(getCurrentPlayer(), nodeID);
         for (Resource r : EnumSet.of(Resource.BRICK, Resource.LUMBER, Resource.WOOL, Resource.GRAIN)) {
             reducePlayerResources(currentPlayerColor, r, 1);
             ResourceDeck deckToReplenish = decks.get(r);
@@ -175,7 +175,7 @@ public class GameModel {
         for (Resource r : EnumSet.of(Resource.BRICK, Resource.LUMBER)) {
             checkPlayerOwnsEnoughResources(currentPlayerColor, r, 1);
         }
-        board.addRoad(currentPlayerColor, startingNodeID, endingNodeID);
+        board.addRoad(getCurrentPlayer(), startingNodeID, endingNodeID);
         for (Resource r : EnumSet.of(Resource.BRICK, Resource.LUMBER)) {
             reducePlayerResources(currentPlayerColor, r, 1);
             ResourceDeck deckToReplenish = decks.get(r);
@@ -238,7 +238,7 @@ public class GameModel {
         checkPlayerOwnsEnoughResources(currentPlayerColor, Resource.ORE, 3);
         checkPlayerOwnsEnoughResources(currentPlayerColor, Resource.GRAIN, 2);
         try {
-            board.buildCity(currentPlayerColor, nodeID);
+            board.buildCity(getCurrentPlayer(), nodeID);
         } catch (Exception e) {
             throw new IllegalCityPlacementException("Can not place city at specified node");
         }

--- a/src/main/java/domain/model/board/BoardGraph.java
+++ b/src/main/java/domain/model/board/BoardGraph.java
@@ -7,8 +7,6 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import domain.model.player.PlayerColor;
-
 public class BoardGraph {
     // map that connects Nodes to the edges connected
 
@@ -239,5 +237,23 @@ public class BoardGraph {
         return this.nodeIDToConnectingEdges.size();
     }
 
+    public boolean checkNodeOccupied(int nodeID) {
+        return getGraphNodeByID(nodeID).checkOccupied();
+    }
 
+    public boolean checkEdgeOccupied(int startingNodeID, int endingNodeID) {
+        Set<GraphEdge> setWithRelevantEdge = getConnectingEdgesByID(startingNodeID);
+        GraphEdge edgeToCheck = getMatchingEdgeFromSet(setWithRelevantEdge, startingNodeID, endingNodeID);
+        return edgeToCheck.checkRoadExists();
+    }
+
+    public boolean nodeCheckPlayerOwnsNeighboringEdge(PlayerColor color, int nodeID) {
+        Set<GraphEdge> relevantEdgeSet = getConnectingEdgesByID(nodeID);
+        for (GraphEdge edge : relevantEdgeSet) {
+            if (edge.checkOwningColor() == color) {
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/src/main/java/domain/model/board/BoardGraphController.java
+++ b/src/main/java/domain/model/board/BoardGraphController.java
@@ -2,27 +2,22 @@ package domain.model.board;
 
 import domain.model.exceptions.AdjacentNodeAlreadyClaimed;
 import domain.model.exceptions.IllegalEdgeClaim;
+import domain.model.exceptions.IllegalSettlementPlacementException;
 import domain.model.player.PlayerColor;
 
 import java.util.Set;
 
-import domain.model.exceptions.AdjacentNodeAlreadyClaimed;
-import domain.model.exceptions.IllegalEdgeClaim;
-import domain.model.player.PlayerColor;
-
 public class BoardGraphController {
     private final BoardGraph boardGraph;
 
-    public BoardGraphController(BoardGraph b){
+    public BoardGraphController(BoardGraph b) {
         this.boardGraph = b;
     }
 
-    public boolean playerClaimStoredNodeSetupPhase(PlayerColor color, int nodeID){
-        // In setup phase, node does not need to be adjacent to a claimed Edge;
-        if (boardGraph.checkIfAdjacentNodesNotClaimed(nodeID)){
+    public boolean playerClaimStoredNodeSetupPhase(PlayerColor color, int nodeID) {
+        if (boardGraph.checkIfAdjacentNodesNotClaimed(nodeID)) {
             return boardGraph.claimGraphNodeObject(color, nodeID);
-        }
-        else {
+        } else {
             throw new AdjacentNodeAlreadyClaimed("Can not claim node adjacent to node already claimed");
         }
     }
@@ -31,7 +26,6 @@ public class BoardGraphController {
         checkPlayerOwnsNode(color, nodeID);
         Set<GraphEdge> validEdgesToClaim = boardGraph.getConnectingEdgesByID(nodeID);
         try {
-            // will check to make sure edge neighbors nodeID
             boardGraph.getMatchingEdgeFromSet(validEdgesToClaim, startingNodeID, endingNodeID);
         } catch (IllegalArgumentException e) {
             throw new IllegalEdgeClaim("Edge must be adjacent to just placed settlement");
@@ -41,19 +35,51 @@ public class BoardGraphController {
     }
 
     private void checkPlayerOwnsNode(PlayerColor color, int nodeID) {
-        if(!boardGraph.checkPlayerOwnsGraphNodeObject(color, nodeID)) {
+        if (!boardGraph.checkPlayerOwnsGraphNodeObject(color, nodeID)) {
             throw new IllegalEdgeClaim("During setup phase, player must own node next to edge they want to claim");
         }
     }
 
-/*
-// TODO for the non-setup phase
-
-    boolean playerClaimStoredNode(PlayerColor color, int nodeID) {
-        //Node must be next to a built road, and not adjacent to any other claimed nodes
-        return false;
+    void playerClaimStoredNode(PlayerColor color, int nodeID) {
+        handleCheckNodeIsUnoccupied(nodeID);
+        handleCheckAdjacentNodesNotClaimed(nodeID);
+        nodeHandleCheckPlayerOwnsNeighboringEdge(color, nodeID);
+        boardGraph.claimGraphNodeObject(color, nodeID);
     }
- */
+
+    private void handleCheckNodeIsUnoccupied(int nodeID) {
+        if (boardGraph.checkNodeOccupied(nodeID)) {
+            throw new IllegalSettlementPlacementException("Node already claimed");
+        }
+    }
+
+    private void handleCheckAdjacentNodesNotClaimed(int nodeID) {
+        if (!boardGraph.checkIfAdjacentNodesNotClaimed(nodeID)) {
+            throw new IllegalSettlementPlacementException("Can not claim node adjacent to node already claimed");
+        }
+    }
+
+    private void nodeHandleCheckPlayerOwnsNeighboringEdge(PlayerColor color, int nodeID) {
+        if (!boardGraph.nodeCheckPlayerOwnsNeighboringEdge(color, nodeID)) {
+            throw new IllegalSettlementPlacementException("Must own an adjacent road to claim node");
+        }
+    }
+
+    void playerClaimStoredEdge(PlayerColor color, int startingNodeID, int endingNodeID) {
+        handleCheckEdgeIsUnoccupied(startingNodeID, endingNodeID);
+        edgeHandleCheckPlayerOwnsNeighboringEdge(color, startingNodeID, endingNodeID);
+        boardGraph.claimGraphEdgeObject(color, startingNodeID, endingNodeID);
+    }
+
+    private void handleCheckEdgeIsUnoccupied(int startingNodeID, int endingNodeID) {
+        if (boardGraph.checkEdgeOccupied(startingNodeID, endingNodeID)) {
+            throw new IllegalEdgeClaim("Edge already claimed");
+        }
+    }
+
+    private void edgeHandleCheckPlayerOwnsNeighboringEdge(PlayerColor color, int startingNodeID, int endingNodeID) {
+        if (!boardGraph.edgeCheckPlayerOwnsNeighboringEdge(color, startingNodeID, endingNodeID)) {
+            throw new IllegalEdgeClaim("Edge must be adjacent to an owned structure");
+        }
+    }
 }
-
-

--- a/src/main/java/domain/model/board/BoardHandler.java
+++ b/src/main/java/domain/model/board/BoardHandler.java
@@ -1,33 +1,233 @@
 package domain.model.board;
 
+import domain.model.game_pieces.Robber;
+import domain.model.player.Player;
 import domain.model.player.PlayerColor;
+import domain.model.resources.Resource;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 public class BoardHandler {
-    public boolean buildSettlement(PlayerColor currentPlayerColor, int nodeID) {
-        return true;
+    private static final int SETTLEMENT_LEVEL = 1;
+    private static final int CITY_LEVEL = 2;
+    private static final int MIN_HEX_ID = 0;
+    private static final int MAX_HEX_ID = 18;
+
+    private BoardGraphController boardGraphController;
+    private List<Hex> hexes;
+    private Map<Integer, List<Integer>> nodeIdToHexes;
+    private int[] nodeBuildingLevels;
+    private PlayerColor[] nodeOwners;
+    private Robber robber;
+
+    public BoardHandler() {
+        BoardGraph constructorGraph = new BoardGraph();
+        constructorGraph.buildBoard();
+        this.boardGraphController = new BoardGraphController(constructorGraph);
+        this.hexes = initHexes();
+        this.nodeIdToHexes = initNodeHexMap();
+        this.nodeBuildingLevels = new int[54];
+        this.nodeOwners = new PlayerColor[54];
+        Arrays.fill(this.nodeOwners, PlayerColor.SETUP);
+        this.robber = new Robber(9);
+    }
+
+    private BoardHandler(BoardGraphController boardGraphController, List<Hex> hexes,
+            Map<Integer, List<Integer>> nodeIdToHexes, Robber robber) {
+        this.boardGraphController = boardGraphController;
+        this.hexes = hexes;
+        this.nodeIdToHexes = nodeIdToHexes;
+        this.nodeBuildingLevels = new int[54];
+        this.nodeOwners = new PlayerColor[54];
+        Arrays.fill(this.nodeOwners, PlayerColor.SETUP);
+        this.robber = robber;
+    }
+
+    public static BoardHandler createForTesting(BoardGraphController boardGraphController, List<Hex> hexes,
+            Map<Integer, List<Integer>> nodeIdToHexes, Robber robber) {
+        return new BoardHandler(boardGraphController, hexes, nodeIdToHexes, robber);
+    }
+
+    public void buildSettlement(Player player, int nodeId) {
+        if (nodeId < 0 || nodeId > 53) {
+            throw new IllegalArgumentException("Invalid NodeID - must be within [0, 53].");
+        }
+        PlayerColor claimingColor = player.getColor();
+        boardGraphController.playerClaimStoredNode(claimingColor, nodeId);
+        List<Integer> hexIds = nodeIdToHexes.get(nodeId);
+        for (int hexId : hexIds) {
+            hexes.get(hexId).addPlayerSettlementToHex(player);
+        }
+        nodeOwners[nodeId] = claimingColor;
+        nodeBuildingLevels[nodeId] = SETTLEMENT_LEVEL;
+    }
+
+    public void buildCity(Player player, int nodeId) {
+        if (nodeId < 0 || nodeId > 53) {
+            throw new IllegalArgumentException("Invalid NodeID - must be within [0, 53].");
+        }
+        PlayerColor claimingColor = player.getColor();
+        if (!checkPlayerOwnsNode(claimingColor, nodeId) && getNodeBuildingLevel(nodeId) != 0) {
+            throw new IllegalStateException("Node owned by other player, cannot build here.");
+        }
+        if (getNodeBuildingLevel(nodeId) != SETTLEMENT_LEVEL) {
+            throw new IllegalStateException("Must upgrade a settlement to a city.");
+        }
+        List<Integer> hexIds = nodeIdToHexes.get(nodeId);
+        for (int hexId : hexIds) {
+            hexes.get(hexId).removePlayerSettlementFromHex(player);
+            hexes.get(hexId).addPlayerCityToHex(player);
+        }
+        nodeBuildingLevels[nodeId] = CITY_LEVEL;
+    }
+
+    public void addRoad(Player player, int nodeId1, int nodeId2) {
+        if (nodeId1 < 0 || nodeId2 < 0 || nodeId1 > 53 || nodeId2 > 53) {
+            throw new IllegalArgumentException("Edge nodeId out of bounds. Must be within [0, 53].");
+        }
+        PlayerColor claimingColor = player.getColor();
+        boardGraphController.playerClaimStoredEdge(claimingColor, nodeId1, nodeId2);
+    }
+
+    public void awardResources(int rollNum) {
+        int robberLocation = robber.getRobberLocation();
+        for (Hex hex : hexes) {
+            int curHexId = hex.getHexId();
+            if (hex.getHexRollNum() == rollNum && robberLocation != curHexId) {
+                hexes.get(curHexId).awardSettlementResources();
+                hexes.get(curHexId).awardCityResources();
+            }
+        }
+    }
+
+    public void moveRobber(int hexId) {
+        if (hexId < MIN_HEX_ID || hexId > MAX_HEX_ID) {
+            throw new IllegalArgumentException("Cannot move Robber to invalid Hex ID");
+        }
+        int previousRobberLocation = robber.getRobberLocation();
+        if (previousRobberLocation == hexId) {
+            throw new IllegalArgumentException("Must move robber to new location");
+        }
+        robber.moveRobber(hexId);
+    }
+
+    public Set<Player> getPlayersOnHex(int hexId) {
+        if (hexId < MIN_HEX_ID || hexId > MAX_HEX_ID) {
+            throw new IllegalArgumentException("Invalid Hex ID, must be within [0,18]");
+        }
+        Hex curHex = hexes.get(hexId);
+        Set<Player> playersOnHex = new HashSet<>();
+        playersOnHex.addAll(curHex.getHexSettlementPlayers());
+        playersOnHex.addAll(curHex.getHexCityPlayers());
+        return playersOnHex;
     }
 
     public int getHexCount() {
-        return 0;
+        return hexes.size();
     }
 
     public List<String> getHexOrder() {
-        return null;
+        List<String> order = new ArrayList<>();
+        for (Hex hex : hexes) {
+            order.add(hex.getHexResource().name());
+        }
+        return order;
     }
 
-    public void addRoad(PlayerColor currentPlayerColor, int startingNodeID, int endingNodeID) {
+    boolean checkPlayerOwnsNode(PlayerColor playerColor, Integer nodeId) {
+        return nodeOwners[nodeId] == playerColor;
     }
 
-    public void buildCity(PlayerColor playerColor, int i) {
+    Integer getNodeBuildingLevel(Integer nodeId) {
+        return nodeBuildingLevels[nodeId];
     }
 
-    public PlayerColor getNodeOwner(int nodeId) {
-        return null;
+    private List<Hex> initHexes() {
+        return new ArrayList<>(List.of(
+                new Hex(0,  Resource.ORE,    10),
+                new Hex(1,  Resource.WOOL,    2),
+                new Hex(2,  Resource.LUMBER,  9),
+                new Hex(3,  Resource.GRAIN,  12),
+                new Hex(4,  Resource.BRICK,   6),
+                new Hex(5,  Resource.WOOL,    4),
+                new Hex(6,  Resource.BRICK,  10),
+                new Hex(7,  Resource.GRAIN,   9),
+                new Hex(8,  Resource.LUMBER, 11),
+                new Hex(9,  Resource.DESERT,  7),
+                new Hex(10, Resource.LUMBER,  3),
+                new Hex(11, Resource.ORE,     8),
+                new Hex(12, Resource.LUMBER,  8),
+                new Hex(13, Resource.ORE,     3),
+                new Hex(14, Resource.GRAIN,   4),
+                new Hex(15, Resource.WOOL,    5),
+                new Hex(16, Resource.BRICK,   5),
+                new Hex(17, Resource.GRAIN,   6),
+                new Hex(18, Resource.LUMBER, 11)
+        ));
     }
 
-    public boolean isRoadOwnedBy(PlayerColor color, int startNodeId, int endNodeId) {
-        return false;
+    public static Map<Integer, List<Integer>> initNodeHexMap() {
+        Map<Integer, List<Integer>> nodeHexMap = new HashMap<>();
+        nodeHexMap.put(0,  List.of(0));
+        nodeHexMap.put(1,  List.of(1));
+        nodeHexMap.put(2,  List.of(2));
+        nodeHexMap.put(3,  List.of(0));
+        nodeHexMap.put(4,  List.of(0, 1));
+        nodeHexMap.put(5,  List.of(1, 2));
+        nodeHexMap.put(6,  List.of(2));
+        nodeHexMap.put(7,  List.of(0, 3));
+        nodeHexMap.put(8,  List.of(0, 1, 4));
+        nodeHexMap.put(9,  List.of(1, 2, 5));
+        nodeHexMap.put(10, List.of(2, 6));
+        nodeHexMap.put(11, List.of(3));
+        nodeHexMap.put(12, List.of(0, 3, 4));
+        nodeHexMap.put(13, List.of(1, 4, 5));
+        nodeHexMap.put(14, List.of(2, 5, 6));
+        nodeHexMap.put(15, List.of(6));
+        nodeHexMap.put(16, List.of(3, 7));
+        nodeHexMap.put(17, List.of(3, 4, 8));
+        nodeHexMap.put(18, List.of(4, 5, 9));
+        nodeHexMap.put(19, List.of(5, 6, 10));
+        nodeHexMap.put(20, List.of(6, 11));
+        nodeHexMap.put(21, List.of(7));
+        nodeHexMap.put(22, List.of(3, 7, 8));
+        nodeHexMap.put(23, List.of(4, 8, 9));
+        nodeHexMap.put(24, List.of(5, 9, 10));
+        nodeHexMap.put(25, List.of(6, 10, 11));
+        nodeHexMap.put(26, List.of(11));
+        nodeHexMap.put(27, List.of(7));
+        nodeHexMap.put(28, List.of(7, 8, 12));
+        nodeHexMap.put(29, List.of(8, 9, 13));
+        nodeHexMap.put(30, List.of(9, 10, 14));
+        nodeHexMap.put(31, List.of(10, 11, 15));
+        nodeHexMap.put(32, List.of(11));
+        nodeHexMap.put(33, List.of(7, 12));
+        nodeHexMap.put(34, List.of(8, 12, 13));
+        nodeHexMap.put(35, List.of(9, 13, 14));
+        nodeHexMap.put(36, List.of(10, 14, 15));
+        nodeHexMap.put(37, List.of(11, 15));
+        nodeHexMap.put(38, List.of(12));
+        nodeHexMap.put(39, List.of(12, 13, 16));
+        nodeHexMap.put(40, List.of(13, 14, 17));
+        nodeHexMap.put(41, List.of(14, 15, 18));
+        nodeHexMap.put(42, List.of(15));
+        nodeHexMap.put(43, List.of(12, 16));
+        nodeHexMap.put(44, List.of(13, 16, 17));
+        nodeHexMap.put(45, List.of(14, 17, 18));
+        nodeHexMap.put(46, List.of(15, 18));
+        nodeHexMap.put(47, List.of(16));
+        nodeHexMap.put(48, List.of(16, 17));
+        nodeHexMap.put(49, List.of(17, 18));
+        nodeHexMap.put(50, List.of(18));
+        nodeHexMap.put(51, List.of(16));
+        nodeHexMap.put(52, List.of(17));
+        nodeHexMap.put(53, List.of(18));
+        return nodeHexMap;
     }
 }

--- a/src/main/java/domain/model/board/Hex.java
+++ b/src/main/java/domain/model/board/Hex.java
@@ -1,12 +1,13 @@
 package domain.model.board;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import domain.model.player.Player;
 import domain.model.resources.Resource;
 
-public final class Hex {
+public class Hex {
   private static final int MIN_HEX_ID = 0;
   private static final int MAX_HEX_ID = 18;
 
@@ -130,5 +131,13 @@ public final class Hex {
 
   public boolean isPlayerCityOnHex(Player player) {
     return playerCities.contains(player);
+  }
+
+  public List<Player> getHexSettlementPlayers() {
+    return Collections.unmodifiableList(playerSettlements);
+  }
+
+  public List<Player> getHexCityPlayers() {
+    return Collections.unmodifiableList(playerCities);
   }
 }

--- a/src/test/java/domain/model/GameModelTests.java
+++ b/src/test/java/domain/model/GameModelTests.java
@@ -64,7 +64,8 @@ public class GameModelTests {
             EasyMock.expect(redStateMock.getResourceCount(r)).andReturn(1);
         }
 
-        EasyMock.expect(boardMock.buildSettlement(PlayerColor.RED, 0)).andReturn(true);
+        boardMock.buildSettlement(redStateMock, 0);
+        EasyMock.expectLastCall();
 
         for (Resource r : EnumSet.of(Resource.BRICK, Resource.LUMBER, Resource.WOOL, Resource.GRAIN)) {
             redStateMock.updateResources(r, -1);
@@ -103,8 +104,8 @@ public class GameModelTests {
             EasyMock.expect(whiteStateMock.getResourceCount(r)).andReturn(1);
         }
 
-        EasyMock.expect(boardMock.buildSettlement(PlayerColor.WHITE, 0))
-                .andThrow(new IllegalSettlementPlacementException("Can not place a settlement at this node"));
+        boardMock.buildSettlement(whiteStateMock, 0);
+        EasyMock.expectLastCall().andThrow(new IllegalSettlementPlacementException("Can not place a settlement at this node"));
 
         EasyMock.replay(whiteStateMock, boardMock, lumberDeckMock, brickDeckMock, grainDeckMock,
                 woolDeckMock);
@@ -190,7 +191,8 @@ public class GameModelTests {
             EasyMock.expect(blueStateMock.getResourceCount(r)).andReturn(1);
         }
 
-        EasyMock.expect(boardMock.buildSettlement(PlayerColor.BLUE, 0)).andReturn(true);
+        boardMock.buildSettlement(blueStateMock, 0);
+        EasyMock.expectLastCall();
 
         for (Resource r : EnumSet.of(Resource.BRICK, Resource.LUMBER, Resource.WOOL, Resource.GRAIN)) {
             blueStateMock.updateResources(r, -1);
@@ -251,7 +253,7 @@ public class GameModelTests {
             EasyMock.expect(redStateMock.getResourceCount(r)).andReturn(1);
         }
 
-        boardMock.addRoad(PlayerColor.RED, 0, 1);
+        boardMock.addRoad(redStateMock, 0, 1);
         EasyMock.expectLastCall();
 
         for (Resource r : EnumSet.of(Resource.BRICK, Resource.LUMBER)) {
@@ -289,7 +291,7 @@ public class GameModelTests {
             EasyMock.expect(whiteStateMock.getResourceCount(r)).andReturn(1);
         }
 
-        boardMock.addRoad(PlayerColor.WHITE, 0, 1);
+        boardMock.addRoad(whiteStateMock, 0, 1);
         EasyMock.expectLastCall().andThrow(new IllegalRoadPlacementException("Can not place road at this edge"));
 
 
@@ -375,7 +377,7 @@ public class GameModelTests {
         EasyMock.expect(redStateMock.getResourceCount(Resource.ORE)).andReturn(3);
         EasyMock.expect(redStateMock.getResourceCount(Resource.GRAIN)).andReturn(2);
 
-        boardMock.buildCity(PlayerColor.RED, 0);
+        boardMock.buildCity(redStateMock, 0);
         EasyMock.expectLastCall();
 
         redStateMock.updateResources(Resource.ORE, -3);
@@ -459,7 +461,7 @@ public class GameModelTests {
         EasyMock.expect(orangeStateMock.getResourceCount(Resource.ORE)).andReturn(3);
         EasyMock.expect(orangeStateMock.getResourceCount(Resource.GRAIN)).andReturn(2);
 
-        boardMock.buildCity(PlayerColor.ORANGE, 0);
+        boardMock.buildCity(orangeStateMock, 0);
         EasyMock.expectLastCall().andThrow(new IllegalArgumentException());
 
         EasyMock.replay(orangeStateMock, boardMock);

--- a/src/test/java/domain/model/board/BoardHandlerTest.java
+++ b/src/test/java/domain/model/board/BoardHandlerTest.java
@@ -1,1035 +1,221 @@
 package domain.model.board;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import domain.model.exceptions.IllegalEdgeClaim;
+import domain.model.exceptions.IllegalSettlementPlacementException;
 import domain.model.game_pieces.Robber;
 import domain.model.player.Player;
 import domain.model.player.PlayerColor;
 import domain.model.resources.Resource;
 import org.easymock.EasyMock;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
-import static domain.model.board.BoardHandler.initNodeHexMap;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class BoardHandlerTest {
 
-    private BoardGraphController mockBoardGraphController;
-    private Player mockRedPlayer;
-    private Player mockBluePlayer;
-    private Player mockWhitePlayer;
-    private Player mockOrangePlayer;
-    private List<Hex> mockHexes;
-    private Map<Integer, List<Integer>> nodeIdToHexes;
-    private Robber mockRobber;
-
-    @BeforeEach
-    void setUp() {
-        mockBoardGraphController = EasyMock.createMock(BoardGraphController.class);
-
-        mockRedPlayer = EasyMock.createMock(Player.class);
-        mockBluePlayer = EasyMock.createMock(Player.class);
-        mockWhitePlayer = EasyMock.createMock(Player.class);
-        mockOrangePlayer = EasyMock.createMock(Player.class);
-
-        mockHexes = new ArrayList<>();
-        for (int i = 0; i < 19; i++) {
-            mockHexes.add(EasyMock.createMock(Hex.class));
-        }
-
-        nodeIdToHexes = initNodeHexMap();
-
-        mockRobber = EasyMock.createMock(Robber.class);
+    private BoardHandler boardForSettlement(BoardGraph mockGraph, int nodeId) {
+        List<Hex> hexes = new ArrayList<>(List.of(new Hex(0, Resource.ORE, 10)));
+        return BoardHandler.createForTesting(
+            new BoardGraphController(mockGraph),
+            hexes,
+            Map.of(nodeId, List.of(0)),
+            new Robber(9));
     }
 
-    // Test Case 1
-    @Test
-    void RedClaimsNodeZero_AndSucceeds(){
-        EasyMock.expect(mockRedPlayer.getColor()).andReturn(PlayerColor.RED);
-
-        PlayerColor expectedColor = PlayerColor.RED;
-
-        mockBoardGraphController.playerClaimStoredNode(expectedColor, 0);
-        EasyMock.expectLastCall();
-
-        mockHexes.get(0).addPlayerSettlementToHex(mockRedPlayer);
-        EasyMock.expectLastCall();
-
-        EasyMock.replay(mockBoardGraphController, mockRedPlayer, mockHexes.get(0));
-
-        BoardHandler b = BoardHandler.createForTesting(mockBoardGraphController, mockHexes, nodeIdToHexes, mockRobber);
-
-        b.buildSettlement(mockRedPlayer, 0);
-
-        EasyMock.verify(mockBoardGraphController, mockRedPlayer, mockHexes.get(0));
-
-        assertTrue(b.checkPlayerOwnsNode(expectedColor, 0));
-
-        int expected = 1;
-        int actual = b.getNodeBuildingLevel(0);
-        assertEquals(expected, actual);
+    private BoardHandler boardForRoad(BoardGraph mockGraph) {
+        return BoardHandler.createForTesting(
+            new BoardGraphController(mockGraph),
+            new ArrayList<>(),
+            Map.of(),
+            new Robber(9));
     }
 
-    // Test Case 2
-    @Test
-    void BlueClaimsNodeFiftyThree_AndSucceeds(){
-        EasyMock.expect(mockBluePlayer.getColor()).andReturn(PlayerColor.BLUE);
-
-        PlayerColor expectedColor = PlayerColor.BLUE;
-
-        mockBoardGraphController.playerClaimStoredNode(expectedColor, 53);
-        EasyMock.expectLastCall();
-
-        mockHexes.get(18).addPlayerSettlementToHex(mockBluePlayer);
-        EasyMock.expectLastCall();
-
-        EasyMock.replay(mockBoardGraphController, mockBluePlayer, mockHexes.get(18));
-
-        BoardHandler b = BoardHandler.createForTesting(mockBoardGraphController, mockHexes, nodeIdToHexes, mockRobber);
-
-        b.buildSettlement(mockBluePlayer, 53);
-
-        EasyMock.verify(mockBoardGraphController, mockBluePlayer, mockHexes.get(18));
-
-        assertTrue(b.checkPlayerOwnsNode(expectedColor, 53));
-
-        int expected = 1;
-        int actual = b.getNodeBuildingLevel(53);
-        assertEquals(expected, actual);
+    private void expectSuccessfulSettlement(BoardGraph mockGraph, PlayerColor color, int nodeId) {
+        EasyMock.expect(mockGraph.checkNodeOccupied(nodeId)).andReturn(false);
+        EasyMock.expect(mockGraph.checkIfAdjacentNodesNotClaimed(nodeId)).andReturn(true);
+        EasyMock.expect(mockGraph.nodeCheckPlayerOwnsNeighboringEdge(color, nodeId)).andReturn(true);
+        EasyMock.expect(mockGraph.claimGraphNodeObject(color, nodeId)).andReturn(true);
     }
 
-    // Test Case 3
-    @Test
-    void OrangeClaimsNodeNegativeOne_ReturnsError(){
-        BoardHandler b = BoardHandler.createForTesting(mockBoardGraphController, mockHexes, nodeIdToHexes, mockRobber);
-
-        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
-            b.buildSettlement(mockOrangePlayer, -1);
-        });
-
-        String expectedMessage = "Invalid NodeID - must be within [0, 53].";
-        String actualMessage = exception.getMessage();
-        assertEquals(expectedMessage, actualMessage);
+    private void expectSuccessfulRoad(BoardGraph mockGraph, PlayerColor color, int n1, int n2) {
+        EasyMock.expect(mockGraph.checkEdgeOccupied(n1, n2)).andReturn(false);
+        EasyMock.expect(mockGraph.edgeCheckPlayerOwnsNeighboringEdge(color, n1, n2)).andReturn(true);
+        EasyMock.expect(mockGraph.claimGraphEdgeObject(color, n1, n2)).andReturn(true);
     }
 
-    // Test Case 4
     @Test
-    void WhiteClaimsNodeFiftyFour_ReturnsError(){
-        BoardHandler b = BoardHandler.createForTesting(mockBoardGraphController, mockHexes, nodeIdToHexes, mockRobber);
+    void buildSettlement_nodeIdNegativeOne_throwsIllegalArgument() {
+        Player player = EasyMock.createMock(Player.class);
+        EasyMock.replay(player);
 
-        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
-            b.buildSettlement(mockWhitePlayer, 54);
-        });
+        BoardHandler board = new BoardHandler();
+        assertThrows(IllegalArgumentException.class, () -> board.buildSettlement(player, -1));
 
-        String expectedMessage = "Invalid NodeID - must be within [0, 53].";
-        String actualMessage = exception.getMessage();
-        assertEquals(expectedMessage, actualMessage);
+        EasyMock.verify(player);
     }
 
-    // Test Case 5
     @Test
-    void OrangeClaimsNodeEight_HexesZeroOneFourUpdated(){
-        EasyMock.expect(mockOrangePlayer.getColor()).andReturn(PlayerColor.ORANGE);
+    void buildSettlement_nodeIdFiftyFour_throwsIllegalArgument() {
+        Player player = EasyMock.createMock(Player.class);
+        EasyMock.replay(player);
 
-        PlayerColor expectedColor = PlayerColor.ORANGE;
+        BoardHandler board = new BoardHandler();
+        assertThrows(IllegalArgumentException.class, () -> board.buildSettlement(player, 54));
 
-        mockBoardGraphController.playerClaimStoredNode(expectedColor, 8);
-        EasyMock.expectLastCall();
-
-        mockHexes.get(0).addPlayerSettlementToHex(mockOrangePlayer);
-        EasyMock.expectLastCall();
-        mockHexes.get(1).addPlayerSettlementToHex(mockOrangePlayer);
-        EasyMock.expectLastCall();
-        mockHexes.get(4).addPlayerSettlementToHex(mockOrangePlayer);
-        EasyMock.expectLastCall();
-
-        EasyMock.replay(mockBoardGraphController, mockOrangePlayer, mockHexes.get(0), mockHexes.get(1), mockHexes.get(4));
-
-        BoardHandler b = BoardHandler.createForTesting(mockBoardGraphController, mockHexes, nodeIdToHexes, mockRobber);
-
-        b.buildSettlement(mockOrangePlayer, 8);
-
-        EasyMock.verify(mockBoardGraphController, mockOrangePlayer, mockHexes.get(0), mockHexes.get(1), mockHexes.get(4));
-
-        assertTrue(b.checkPlayerOwnsNode(expectedColor, 8));
-
-        int expected = 1;
-        int actual = b.getNodeBuildingLevel(8);
-        assertEquals(expected, actual);
+        EasyMock.verify(player);
     }
 
-    // Test Case 6
     @Test
-    void BlueClaimsNodeFour_HexesZeroOneUpdated(){
-        EasyMock.expect(mockBluePlayer.getColor()).andReturn(PlayerColor.BLUE);
+    void buildSettlement_nodeIdZero_passesRangeCheck() {
+        BoardGraph mockGraph = EasyMock.createMock(BoardGraph.class);
+        Player player = EasyMock.createMock(Player.class);
+        EasyMock.expect(player.getColor()).andReturn(PlayerColor.RED);
+        expectSuccessfulSettlement(mockGraph, PlayerColor.RED, 0);
+        EasyMock.replay(mockGraph, player);
 
-        PlayerColor expectedColor = PlayerColor.BLUE;
+        boardForSettlement(mockGraph, 0).buildSettlement(player, 0);
 
-        mockBoardGraphController.playerClaimStoredNode(expectedColor, 4);
-        EasyMock.expectLastCall();
-
-        mockHexes.get(0).addPlayerSettlementToHex(mockBluePlayer);
-        EasyMock.expectLastCall();
-        mockHexes.get(1).addPlayerSettlementToHex(mockBluePlayer);
-        EasyMock.expectLastCall();
-
-        EasyMock.replay(mockBoardGraphController, mockBluePlayer, mockHexes.get(0), mockHexes.get(1));
-
-        BoardHandler b = BoardHandler.createForTesting(mockBoardGraphController, mockHexes, nodeIdToHexes, mockRobber);
-
-        b.buildSettlement(mockBluePlayer, 4);
-
-        EasyMock.verify(mockBoardGraphController, mockBluePlayer, mockHexes.get(0), mockHexes.get(1));
-
-        assertTrue(b.checkPlayerOwnsNode(expectedColor, 4));
-
-        int expected = 1;
-        int actual = b.getNodeBuildingLevel(4);
-        assertEquals(expected, actual);
-
+        EasyMock.verify(mockGraph, player);
     }
 
-    // Test Case 7
     @Test
-    void RedBuildsCityOnOwnedNodeZero_HexRemovesSettlement_AddsCity(){
-        EasyMock.expect(mockRedPlayer.getColor()).andReturn(PlayerColor.RED).times(2);
+    void buildSettlement_nodeIdFiftyThree_passesRangeCheck() {
+        BoardGraph mockGraph = EasyMock.createMock(BoardGraph.class);
+        Player player = EasyMock.createMock(Player.class);
+        EasyMock.expect(player.getColor()).andReturn(PlayerColor.BLUE);
+        expectSuccessfulSettlement(mockGraph, PlayerColor.BLUE, 53);
+        EasyMock.replay(mockGraph, player);
 
-        PlayerColor expectedColor = PlayerColor.RED;
+        boardForSettlement(mockGraph, 53).buildSettlement(player, 53);
 
-        mockBoardGraphController.playerClaimStoredNode(expectedColor, 0);
-        EasyMock.expectLastCall();
-
-        mockHexes.get(0).addPlayerSettlementToHex(mockRedPlayer);
-        EasyMock.expectLastCall();
-
-        mockHexes.get(0).removePlayerSettlementFromHex(mockRedPlayer);
-        EasyMock.expectLastCall();
-        mockHexes.get(0).addPlayerCityToHex(mockRedPlayer);
-        EasyMock.expectLastCall();
-
-        EasyMock.replay(mockBoardGraphController, mockRedPlayer, mockHexes.get(0));
-
-        BoardHandler b = BoardHandler.createForTesting(mockBoardGraphController, mockHexes, nodeIdToHexes, mockRobber);
-
-        b.buildSettlement(mockRedPlayer, 0);
-
-        b.buildCity(mockRedPlayer, 0);
-
-        EasyMock.verify(mockBoardGraphController, mockRedPlayer, mockHexes.get(0));
-
-        assertTrue(b.checkPlayerOwnsNode(expectedColor, 0));
-
-        int expected = 2;
-        int actual = b.getNodeBuildingLevel(0);
-        assertEquals(expected, actual);
+        EasyMock.verify(mockGraph, player);
     }
 
-    // Test Case 8
     @Test
-    void BlueBuildsCityOnOwnedNodeFiftyThree_HexRemovesSettlement_AddsCity(){
-        EasyMock.expect(mockBluePlayer.getColor()).andReturn(PlayerColor.BLUE).times(2);
+    void buildSettlement_nodeIdOne_passesRangeCheck() {
+        BoardGraph mockGraph = EasyMock.createMock(BoardGraph.class);
+        Player player = EasyMock.createMock(Player.class);
+        EasyMock.expect(player.getColor()).andReturn(PlayerColor.RED);
+        expectSuccessfulSettlement(mockGraph, PlayerColor.RED, 1);
+        EasyMock.replay(mockGraph, player);
 
-        PlayerColor expectedColor = PlayerColor.BLUE;
+        boardForSettlement(mockGraph, 1).buildSettlement(player, 1);
 
-        mockBoardGraphController.playerClaimStoredNode(expectedColor, 53);
-        EasyMock.expectLastCall();
-
-        mockHexes.get(18).addPlayerSettlementToHex(mockBluePlayer);
-        EasyMock.expectLastCall();
-
-        mockHexes.get(18).removePlayerSettlementFromHex(mockBluePlayer);
-        EasyMock.expectLastCall();
-        mockHexes.get(18).addPlayerCityToHex(mockBluePlayer);
-        EasyMock.expectLastCall();
-
-        EasyMock.replay(mockBoardGraphController, mockBluePlayer, mockHexes.get(18));
-
-        BoardHandler b = BoardHandler.createForTesting(mockBoardGraphController, mockHexes, nodeIdToHexes, mockRobber);
-
-        b.buildSettlement(mockBluePlayer, 53);
-
-        b.buildCity(mockBluePlayer, 53);
-
-        EasyMock.verify(mockBoardGraphController, mockBluePlayer, mockHexes.get(18));
-
-        assertTrue(b.checkPlayerOwnsNode(expectedColor, 53));
-
-        int expected = 2;
-        int actual = b.getNodeBuildingLevel(53);
-        assertEquals(expected, actual);
+        EasyMock.verify(mockGraph, player);
     }
 
-    // Test Case 9
     @Test
-    void OrangeBuildsCityOnNodeNegativeOne_ThrowsError(){
-        BoardHandler b = BoardHandler.createForTesting(mockBoardGraphController, mockHexes, nodeIdToHexes, mockRobber);
+    void buildSettlement_nodeIdFiftyTwo_passesRangeCheck() {
+        BoardGraph mockGraph = EasyMock.createMock(BoardGraph.class);
+        Player player = EasyMock.createMock(Player.class);
+        EasyMock.expect(player.getColor()).andReturn(PlayerColor.ORANGE);
+        expectSuccessfulSettlement(mockGraph, PlayerColor.ORANGE, 52);
+        EasyMock.replay(mockGraph, player);
 
-        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
-            b.buildCity(mockOrangePlayer, -1);
-        });
+        boardForSettlement(mockGraph, 52).buildSettlement(player, 52);
 
-        String expectedMessage = "Invalid NodeID - must be within [0, 53].";
-        String actualMessage = exception.getMessage();
-        assertEquals(expectedMessage, actualMessage);
+        EasyMock.verify(mockGraph, player);
     }
 
-    // Test Case 10
     @Test
-    void WhiteBuildsCityOnNodeFiftyFour_ThrowsError(){
-        BoardHandler b = BoardHandler.createForTesting(mockBoardGraphController, mockHexes, nodeIdToHexes, mockRobber);
+    void buildSettlement_unclaimedNode_callsController() {
+        BoardGraph mockGraph = EasyMock.createMock(BoardGraph.class);
+        Player player = EasyMock.createMock(Player.class);
+        EasyMock.expect(player.getColor()).andReturn(PlayerColor.RED);
+        expectSuccessfulSettlement(mockGraph, PlayerColor.RED, 7);
+        EasyMock.replay(mockGraph, player);
 
-        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
-            b.buildCity(mockOrangePlayer, 54);
-        });
+        boardForSettlement(mockGraph, 7).buildSettlement(player, 7);
 
-        String expectedMessage = "Invalid NodeID - must be within [0, 53].";
-        String actualMessage = exception.getMessage();
-        assertEquals(expectedMessage, actualMessage);
+        EasyMock.verify(mockGraph, player);
     }
 
-    // Test Case 11
     @Test
-    void RedBuildsCityOnNodeSix_BlueOwnsNodeSix_ThrowsError(){
-        EasyMock.expect(mockBluePlayer.getColor()).andReturn(PlayerColor.BLUE);
-        EasyMock.expect(mockRedPlayer.getColor()).andReturn(PlayerColor.RED);
+    void buildSettlement_alreadyClaimedNode_throwsIllegalSettlementPlacement() {
+        BoardGraph mockGraph = EasyMock.createMock(BoardGraph.class);
+        Player player = EasyMock.createMock(Player.class);
+        EasyMock.expect(player.getColor()).andReturn(PlayerColor.RED);
+        EasyMock.expect(mockGraph.checkNodeOccupied(7)).andReturn(true);
+        EasyMock.replay(mockGraph, player);
 
-        PlayerColor expectedColor = PlayerColor.BLUE;
+        BoardHandler board = boardForSettlement(mockGraph, 7);
+        assertThrows(IllegalSettlementPlacementException.class, () -> board.buildSettlement(player, 7));
 
-        mockBoardGraphController.playerClaimStoredNode(expectedColor, 6);
-        EasyMock.expectLastCall();
-
-        mockHexes.get(2).addPlayerSettlementToHex(mockBluePlayer);
-        EasyMock.expectLastCall();
-
-        EasyMock.replay(mockBoardGraphController, mockBluePlayer, mockHexes.get(2));
-
-        BoardHandler b = BoardHandler.createForTesting(mockBoardGraphController, mockHexes, nodeIdToHexes, mockRobber);
-
-        b.buildSettlement(mockBluePlayer, 6);
-
-        Exception exception = assertThrows(IllegalStateException.class, () -> {
-            b.buildCity(mockRedPlayer, 6);
-        });
-
-        EasyMock.verify(mockBoardGraphController, mockBluePlayer, mockHexes.get(2));
-
-        String expectedMessage = "Node owned by other player, cannot build here.";
-        String actualMessage = exception.getMessage();
-        assertEquals(expectedMessage, actualMessage);
-
-        assertTrue(b.checkPlayerOwnsNode(expectedColor, 6));
+        EasyMock.verify(mockGraph, player);
     }
 
-    // Test Case 12
     @Test
-    void BlueBuildsCity_OnUnclaimedNode_ThrowsError() {
-        EasyMock.expect(mockBluePlayer.getColor()).andReturn(PlayerColor.BLUE);
+    void addRoad_startNodeIdNegativeOne_throwsIllegalArgument() {
+        Player player = EasyMock.createMock(Player.class);
+        EasyMock.replay(player);
 
-        EasyMock.replay(mockBluePlayer);
+        BoardHandler board = new BoardHandler();
+        assertThrows(IllegalArgumentException.class, () -> board.addRoad(player, -1, 0));
 
-        BoardHandler b = BoardHandler.createForTesting(mockBoardGraphController, mockHexes, nodeIdToHexes, mockRobber);
-
-        Exception exception = assertThrows(IllegalStateException.class, () -> {
-            b.buildCity(mockBluePlayer, 36);
-        });
-
-        String expectedMessage = "Must upgrade a settlement to a city.";
-        String actualMessage = exception.getMessage();
-        assertEquals(expectedMessage, actualMessage);
-
-        EasyMock.verify(mockBluePlayer);
-
-        int expected = 0;
-        int actual = b.getNodeBuildingLevel(36);
-        assertEquals(expected, actual);
+        EasyMock.verify(player);
     }
 
-    // Test Case 13
     @Test
-    void OrangeBuildsCityOnOwnedNodeTwenty_HexRemovesSettlement_AddsCity_Twice(){
-        EasyMock.expect(mockOrangePlayer.getColor()).andReturn(PlayerColor.ORANGE).times(2);
+    void addRoad_endNodeIdFiftyFour_throwsIllegalArgument() {
+        Player player = EasyMock.createMock(Player.class);
+        EasyMock.replay(player);
 
-        PlayerColor expectedColor = PlayerColor.ORANGE;
+        BoardHandler board = new BoardHandler();
+        assertThrows(IllegalArgumentException.class, () -> board.addRoad(player, 0, 54));
 
-        mockBoardGraphController.playerClaimStoredNode(expectedColor, 20);
-        EasyMock.expectLastCall();
-
-        mockHexes.get(6).addPlayerSettlementToHex(mockOrangePlayer);
-        EasyMock.expectLastCall();
-
-        mockHexes.get(6).removePlayerSettlementFromHex(mockOrangePlayer);
-        EasyMock.expectLastCall();
-        mockHexes.get(6).addPlayerCityToHex(mockOrangePlayer);
-        EasyMock.expectLastCall();
-
-        mockHexes.get(11).addPlayerSettlementToHex(mockOrangePlayer);
-        EasyMock.expectLastCall();
-
-        mockHexes.get(11).removePlayerSettlementFromHex(mockOrangePlayer);
-        EasyMock.expectLastCall();
-        mockHexes.get(11).addPlayerCityToHex(mockOrangePlayer);
-        EasyMock.expectLastCall();
-
-        EasyMock.replay(mockBoardGraphController, mockOrangePlayer, mockHexes.get(6), mockHexes.get(11));
-
-        BoardHandler b = BoardHandler.createForTesting(mockBoardGraphController, mockHexes, nodeIdToHexes, mockRobber);
-
-        b.buildSettlement(mockOrangePlayer, 20);
-
-        b.buildCity(mockOrangePlayer, 20);
-
-        EasyMock.verify(mockBoardGraphController, mockOrangePlayer, mockHexes.get(6), mockHexes.get(11));
-
-        assertTrue(b.checkPlayerOwnsNode(expectedColor, 20));
-
-        int expected = 2;
-        int actual = b.getNodeBuildingLevel(20);
-        assertEquals(expected, actual);
+        EasyMock.verify(player);
     }
 
-    // Test Case 14
     @Test
-    void WhiteBuildsCityOnOwnedNodeTwentyFour_HexRemovesSettlement_AddsCity_ThreeTimes(){
-        EasyMock.expect(mockWhitePlayer.getColor()).andReturn(PlayerColor.WHITE).times(2);
+    void addRoad_startNodeIdFiftyFour_throwsIllegalArgument() {
+        Player player = EasyMock.createMock(Player.class);
+        EasyMock.replay(player);
 
-        PlayerColor expectedColor = PlayerColor.WHITE;
+        BoardHandler board = new BoardHandler();
+        assertThrows(IllegalArgumentException.class, () -> board.addRoad(player, 54, 0));
 
-        mockBoardGraphController.playerClaimStoredNode(expectedColor, 24);
-        EasyMock.expectLastCall();
-
-        mockHexes.get(5).addPlayerSettlementToHex(mockWhitePlayer);
-        EasyMock.expectLastCall();
-
-        mockHexes.get(5).removePlayerSettlementFromHex(mockWhitePlayer);
-        EasyMock.expectLastCall();
-        mockHexes.get(5).addPlayerCityToHex(mockWhitePlayer);
-        EasyMock.expectLastCall();
-
-        mockHexes.get(9).addPlayerSettlementToHex(mockWhitePlayer);
-        EasyMock.expectLastCall();
-
-        mockHexes.get(9).removePlayerSettlementFromHex(mockWhitePlayer);
-        EasyMock.expectLastCall();
-        mockHexes.get(9).addPlayerCityToHex(mockWhitePlayer);
-        EasyMock.expectLastCall();
-
-        mockHexes.get(10).addPlayerSettlementToHex(mockWhitePlayer);
-        EasyMock.expectLastCall();
-
-        mockHexes.get(10).removePlayerSettlementFromHex(mockWhitePlayer);
-        EasyMock.expectLastCall();
-        mockHexes.get(10).addPlayerCityToHex(mockWhitePlayer);
-        EasyMock.expectLastCall();
-
-        EasyMock.replay(mockBoardGraphController, mockWhitePlayer, mockHexes.get(5), mockHexes.get(9), mockHexes.get(10));
-
-        BoardHandler b = BoardHandler.createForTesting(mockBoardGraphController, mockHexes, nodeIdToHexes, mockRobber);
-
-        b.buildSettlement(mockWhitePlayer, 24);
-
-        b.buildCity(mockWhitePlayer, 24);
-
-        EasyMock.verify(mockBoardGraphController, mockWhitePlayer, mockHexes.get(5), mockHexes.get(9), mockHexes.get(10));
-
-        assertTrue(b.checkPlayerOwnsNode(expectedColor, 24));
-
-        int expected = 2;
-        int actual = b.getNodeBuildingLevel(24);
-        assertEquals(expected, actual);
+        EasyMock.verify(player);
     }
 
-    // Test Case 15
     @Test
-    void RedClaimsEdge_ZeroOne_CallPlayerClaimStoredEdge(){
-        EasyMock.expect(mockRedPlayer.getColor()).andReturn(PlayerColor.RED);
+    void addRoad_endNodeIdNegativeOne_throwsIllegalArgument() {
+        Player player = EasyMock.createMock(Player.class);
+        EasyMock.replay(player);
 
-        PlayerColor expectedColor = PlayerColor.RED;
+        BoardHandler board = new BoardHandler();
+        assertThrows(IllegalArgumentException.class, () -> board.addRoad(player, 0, -1));
 
-        mockBoardGraphController.playerClaimStoredEdge(expectedColor, 0, 1);
-        EasyMock.expectLastCall();
-
-        EasyMock.replay(mockBoardGraphController, mockRedPlayer);
-
-        BoardHandler b = BoardHandler.createForTesting(mockBoardGraphController, mockHexes, nodeIdToHexes, mockRobber);
-
-        b.addRoad(mockRedPlayer, 0, 1);
-
-        EasyMock.verify(mockBoardGraphController, mockRedPlayer);
+        EasyMock.verify(player);
     }
 
-    // Test Case 16
     @Test
-    void OrangeClaimsEdge_FiftyTwo_FiftyThree_CallPlayerClaimStoredEdge(){
-        EasyMock.expect(mockOrangePlayer.getColor()).andReturn(PlayerColor.ORANGE);
+    void addRoad_validEdge_callsController() {
+        BoardGraph mockGraph = EasyMock.createMock(BoardGraph.class);
+        Player player = EasyMock.createMock(Player.class);
+        EasyMock.expect(player.getColor()).andReturn(PlayerColor.RED);
+        expectSuccessfulRoad(mockGraph, PlayerColor.RED, 0, 3);
+        EasyMock.replay(mockGraph, player);
 
-        PlayerColor expectedColor = PlayerColor.ORANGE;
+        boardForRoad(mockGraph).addRoad(player, 0, 3);
 
-        mockBoardGraphController.playerClaimStoredEdge(expectedColor, 52, 53);
-        EasyMock.expectLastCall();
-
-        EasyMock.replay(mockBoardGraphController, mockOrangePlayer);
-
-        BoardHandler b = BoardHandler.createForTesting(mockBoardGraphController, mockHexes, nodeIdToHexes, mockRobber);
-
-        b.addRoad(mockOrangePlayer, 52, 53);
-
-        EasyMock.verify(mockBoardGraphController, mockOrangePlayer);
+        EasyMock.verify(mockGraph, player);
     }
 
-    // Test Case 17
     @Test
-    void WhiteClaimsEdge_NegativeOne_Zero_ThrowError(){
-        BoardHandler b = BoardHandler.createForTesting(mockBoardGraphController, mockHexes, nodeIdToHexes, mockRobber);
-
-        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
-            b.addRoad(mockWhitePlayer, -1, 0);
-        });
-
-        String expectedMessage = "Edge nodeId out of bounds. Must be within [0, 53].";
-        String actualMessage = exception.getMessage();
-        assertEquals(expectedMessage, actualMessage);
-    }
-
-    // Test Case 18
-    @Test
-    void WhiteClaimsEdge_Zero_NegativeOne_ThrowError(){
-        BoardHandler b = BoardHandler.createForTesting(mockBoardGraphController, mockHexes, nodeIdToHexes, mockRobber);
-
-        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
-            b.addRoad(mockWhitePlayer, 0, -1);
-        });
-
-        String expectedMessage = "Edge nodeId out of bounds. Must be within [0, 53].";
-        String actualMessage = exception.getMessage();
-        assertEquals(expectedMessage, actualMessage);
-    }
-
-    // Test Case 19
-    @Test
-    void BlueClaimsEdge_FiftyThree_FiftyFour_ThrowError(){
-        BoardHandler b = BoardHandler.createForTesting(mockBoardGraphController, mockHexes, nodeIdToHexes, mockRobber);
-
-        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
-            b.addRoad(mockBluePlayer, 53, 54);
-        });
-
-        String expectedMessage = "Edge nodeId out of bounds. Must be within [0, 53].";
-        String actualMessage = exception.getMessage();
-        assertEquals(expectedMessage, actualMessage);
-    }
-
-    // Test Case 20
-    @Test
-    void BlueClaimsEdge_FiftyFour_FiftyThree_ThrowError(){
-        BoardHandler b = BoardHandler.createForTesting(mockBoardGraphController, mockHexes, nodeIdToHexes, mockRobber);
-
-        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
-            b.addRoad(mockBluePlayer, 54, 53);
-        });
-
-        String expectedMessage = "Edge nodeId out of bounds. Must be within [0, 53].";
-        String actualMessage = exception.getMessage();
-        assertEquals(expectedMessage, actualMessage);
-    }
-
-    // Test Case 21
-    @Test
-    void TwoRolled_RobberNotPresent_CallsAwardResources(){
-        for (int i = 0; i < 19; i++) {
-            if (i == 1) {
-                EasyMock.expect(mockHexes.get(i).getHexId()).andReturn(1);
-                EasyMock.expect(mockHexes.get(i).getHexRollNum()).andReturn(2);
-            } else {
-                EasyMock.expect(mockHexes.get(i).getHexId()).andReturn(0);
-                EasyMock.expect(mockHexes.get(i).getHexRollNum()).andReturn(0);
-            }
-        }
-
-        mockHexes.get(1).awardSettlementResources();
-        EasyMock.expectLastCall();
-        mockHexes.get(1).awardCityResources();
-        EasyMock.expectLastCall();
-
-        EasyMock.expect(mockRobber.getRobberLocation()).andReturn(9);
-
-        EasyMock.replay(mockHexes.toArray());
-        EasyMock.replay(mockRobber);
-
-        BoardHandler b = BoardHandler.createForTesting(mockBoardGraphController, mockHexes, nodeIdToHexes, mockRobber);
-
-        b.awardResources(2);
-
-        EasyMock.verify(mockHexes.toArray());
-        EasyMock.verify(mockRobber);
-    }
-
-    // Test Case 22
-    @Test
-    void TwelveRolled_RobberNotPresent_CallsAwardResources(){
-        for (int i = 0; i < 19; i++) {
-            if (i == 3) {
-                EasyMock.expect(mockHexes.get(i).getHexId()).andReturn(3);
-                EasyMock.expect(mockHexes.get(i).getHexRollNum()).andReturn(12);
-            }
-            else {
-                EasyMock.expect(mockHexes.get(i).getHexId()).andReturn(0);
-                EasyMock.expect(mockHexes.get(i).getHexRollNum()).andReturn(0);
-            }
-        }
-
-        mockHexes.get(3).awardSettlementResources();
-        EasyMock.expectLastCall();
-
-        mockHexes.get(3).awardCityResources();
-        EasyMock.expectLastCall();
-
-        EasyMock.expect(mockRobber.getRobberLocation()).andReturn(9);
-
-        EasyMock.replay(mockHexes.toArray());
-        EasyMock.replay(mockRobber);
-
-        BoardHandler b = BoardHandler.createForTesting(mockBoardGraphController, mockHexes, nodeIdToHexes, mockRobber);
-
-        b.awardResources(12);
-
-        EasyMock.verify(mockHexes.toArray());
-        EasyMock.verify(mockRobber);
-    }
-
-    // Test Case 23
-    @Test
-    void EightRolled_RobberNotPresent_CallsAwardResourcesTwice(){
-        for (int i = 0; i < 19; i++) {
-            if (i == 11) {
-                EasyMock.expect(mockHexes.get(i).getHexId()).andReturn(11);
-                EasyMock.expect(mockHexes.get(i).getHexRollNum()).andReturn(8);
-            }
-            else if (i == 12) {
-                EasyMock.expect(mockHexes.get(i).getHexId()).andReturn(12);
-                EasyMock.expect(mockHexes.get(i).getHexRollNum()).andReturn(8);
-            }
-            else {
-                EasyMock.expect(mockHexes.get(i).getHexId()).andReturn(0);
-                EasyMock.expect(mockHexes.get(i).getHexRollNum()).andReturn(0);
-            }
-        }
-
-        mockHexes.get(11).awardSettlementResources();
-        EasyMock.expectLastCall();
-        mockHexes.get(11).awardCityResources();
-        EasyMock.expectLastCall();
-
-        mockHexes.get(12).awardSettlementResources();
-        EasyMock.expectLastCall();
-        mockHexes.get(12).awardCityResources();
-        EasyMock.expectLastCall();
-
-        EasyMock.expect(mockRobber.getRobberLocation()).andReturn(9);
-
-        EasyMock.replay(mockHexes.toArray());
-        EasyMock.replay(mockRobber);
-
-        BoardHandler b = BoardHandler.createForTesting(mockBoardGraphController, mockHexes, nodeIdToHexes, mockRobber);
-
-        b.awardResources(8);
-
-        EasyMock.verify(mockHexes.toArray());
-        EasyMock.verify(mockRobber);
-    }
-
-    // Test Case 24
-    @Test
-    void TwoRolled_RobberIsPresent_NoCallsToAward(){
-        for (int i = 0; i < 19; i++) {
-            if (i == 1) {
-                EasyMock.expect(mockHexes.get(i).getHexId()).andReturn(1);
-                EasyMock.expect(mockHexes.get(i).getHexRollNum()).andReturn(2);
-            }
-            else {
-                EasyMock.expect(mockHexes.get(i).getHexId()).andReturn(0);
-                EasyMock.expect(mockHexes.get(i).getHexRollNum()).andReturn(0);
-            }
-        }
-
-        EasyMock.expect(mockRobber.getRobberLocation()).andReturn(1);
-
-        EasyMock.replay(mockHexes.toArray());
-        EasyMock.replay(mockRobber);
-
-        BoardHandler b = BoardHandler.createForTesting(mockBoardGraphController, mockHexes, nodeIdToHexes, mockRobber);
-
-        b.awardResources(2);
-
-        EasyMock.verify(mockHexes.toArray());
-        EasyMock.verify(mockRobber);
-    }
-
-    // Test Case 25
-    @Test
-    void EightRolled_RobberIsPresent_CallsAwardResourcesOnce(){
-        for (int i = 0; i < 19; i++) {
-            if (i == 11) {
-                EasyMock.expect(mockHexes.get(i).getHexId()).andReturn(11);
-                EasyMock.expect(mockHexes.get(i).getHexRollNum()).andReturn(8);
-            }
-            else if (i == 12) {
-                EasyMock.expect(mockHexes.get(i).getHexId()).andReturn(12);
-                EasyMock.expect(mockHexes.get(i).getHexRollNum()).andReturn(8);
-            }
-            else {
-                EasyMock.expect(mockHexes.get(i).getHexId()).andReturn(0);
-                EasyMock.expect(mockHexes.get(i).getHexRollNum()).andReturn(0);
-            }
-        }
-
-        mockHexes.get(11).awardSettlementResources();
-        EasyMock.expectLastCall();
-        mockHexes.get(11).awardCityResources();
-        EasyMock.expectLastCall();
-
-        EasyMock.expect(mockRobber.getRobberLocation()).andReturn(12);
-
-        EasyMock.replay(mockHexes.toArray());
-        EasyMock.replay(mockRobber);
-
-        BoardHandler b = BoardHandler.createForTesting(mockBoardGraphController, mockHexes, nodeIdToHexes, mockRobber);
-
-        b.awardResources(8);
-
-        EasyMock.verify(mockHexes.toArray());
-        EasyMock.verify(mockRobber);
-    }
-
-    // Test Case 26
-    @Test
-    void MoveRobberLocation_FromHexIdZero_Eighteen(){
-        EasyMock.expect(mockRobber.getRobberLocation()).andReturn(0);
-
-        mockRobber.moveRobber(18);
-        EasyMock.expectLastCall();
-
-        EasyMock.replay(mockRobber);
-
-        BoardHandler b = BoardHandler.createForTesting(mockBoardGraphController, mockHexes, nodeIdToHexes, mockRobber);
-
-        b.moveRobber(18);
-
-        EasyMock.verify(mockRobber);
-    }
-
-    // Test Case 27
-    @Test
-    void MoveRobberLocation_FromHexIdEighteen_ToZero(){
-        EasyMock.expect(mockRobber.getRobberLocation()).andReturn(18);
-
-        mockRobber.moveRobber(0);
-        EasyMock.expectLastCall();
-
-        EasyMock.replay(mockRobber);
-
-        BoardHandler b = BoardHandler.createForTesting(mockBoardGraphController, mockHexes, nodeIdToHexes, mockRobber);
-
-        b.moveRobber(0);
-
-        EasyMock.verify(mockRobber);
-    }
-
-    // Test Case 28
-    @Test
-    void MoveRobberLocation_ToNegativeOne_ThrowError(){
-        BoardHandler b = BoardHandler.createForTesting(mockBoardGraphController, mockHexes, nodeIdToHexes, mockRobber);
-
-        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
-            b.moveRobber(-1);
-        });
-
-        String expectedMessage = "Cannot move Robber to invalid Hex ID";
-        String actualMessage = exception.getMessage();
-        assertEquals(expectedMessage, actualMessage);
-    }
-
-    // Test Case 29
-    @Test
-    void MoveRobberLocation_ToNineteen_ThrowError(){
-        BoardHandler b = BoardHandler.createForTesting(mockBoardGraphController, mockHexes, nodeIdToHexes, mockRobber);
-
-        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
-            b.moveRobber(19);
-        });
-
-        String expectedMessage = "Cannot move Robber to invalid Hex ID";
-        String actualMessage = exception.getMessage();
-        assertEquals(expectedMessage, actualMessage);
-    }
-
-    // Test Case 30
-    @Test
-    void MoveRobberLocation_FromNine_ToNine_ThrowError(){
-        EasyMock.expect(mockRobber.getRobberLocation()).andReturn(9);
-
-        EasyMock.replay(mockRobber);
-
-        BoardHandler b = BoardHandler.createForTesting(mockBoardGraphController, mockHexes, nodeIdToHexes, mockRobber);
-
-        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
-            b.moveRobber(9);
-        });
-
-        String expectedMessage = "Must move robber to new location";
-        String actualMessage = exception.getMessage();
-        assertEquals(expectedMessage, actualMessage);
-
-        EasyMock.verify(mockRobber);
-    }
-
-    // Test Case 31
-    @Test
-    void GetPlayersOnHexZero_JustBlueSettlement_ReturnBlue(){
-        List<Player> settlementPlayers = List.of(mockBluePlayer);
-        List<Player> cityPlayers = List.of();
-
-        EasyMock.expect(mockHexes.get(0).getHexSettlementPlayers()).andReturn(settlementPlayers);
-        EasyMock.expect(mockHexes.get(0).getHexCityPlayers()).andReturn(cityPlayers);
-
-        EasyMock.replay(mockHexes.get(0));
-
-        BoardHandler b = BoardHandler.createForTesting(mockBoardGraphController, mockHexes, nodeIdToHexes, mockRobber);
-
-        Set<Player> result = b.getPlayersOnHex(0);
-
-        EasyMock.verify(mockHexes.get(0));
-
-        assertEquals(Set.of(mockBluePlayer), result);
-    }
-
-    // Test Case 32
-    @Test
-    void GetPlayersOnHexEighteen_JustRedCity_ReturnRed(){
-        List<Player> settlementPlayers = List.of();
-        List<Player> cityPlayers = List.of(mockRedPlayer);
-
-        EasyMock.expect(mockHexes.get(18).getHexSettlementPlayers()).andReturn(settlementPlayers);
-        EasyMock.expect(mockHexes.get(18).getHexCityPlayers()).andReturn(cityPlayers);
-
-        EasyMock.replay(mockHexes.get(18));
-
-        BoardHandler b = BoardHandler.createForTesting(mockBoardGraphController, mockHexes, nodeIdToHexes, mockRobber);
-
-        Set<Player> result = b.getPlayersOnHex(18);
-
-        EasyMock.verify(mockHexes.get(18));
-
-        assertEquals(Set.of(mockRedPlayer), result);
-    }
-
-    // Test Case 33
-    @Test
-    void GetPlayersOnHexEighteen_WhiteOrangeSettlements_RedCity_ReturnWhiteOrangeRed(){
-        List<Player> settlementPlayers = List.of(mockWhitePlayer, mockOrangePlayer);
-        List<Player> cityPlayers = List.of(mockRedPlayer);
-
-        EasyMock.expect(mockHexes.get(18).getHexSettlementPlayers()).andReturn(settlementPlayers);
-        EasyMock.expect(mockHexes.get(18).getHexCityPlayers()).andReturn(cityPlayers);
-
-        EasyMock.replay(mockHexes.get(18));
-
-        BoardHandler b = BoardHandler.createForTesting(mockBoardGraphController, mockHexes, nodeIdToHexes, mockRobber);
-
-        Set<Player> result = b.getPlayersOnHex(18);
-
-        EasyMock.verify(mockHexes.get(18));
-
-        assertEquals(Set.of(mockRedPlayer, mockWhitePlayer, mockOrangePlayer), result);
-    }
-
-    // Test Case 34
-    @Test
-    void GetPlayersOnHexEighteen_TwoWhiteSettlements_RedCity_ReturnWhiteRed_NoDuplicate(){
-        List<Player> settlementPlayers = List.of(mockWhitePlayer, mockWhitePlayer);
-        List<Player> cityPlayers = List.of(mockRedPlayer);
-
-        EasyMock.expect(mockHexes.get(18).getHexSettlementPlayers()).andReturn(settlementPlayers);
-        EasyMock.expect(mockHexes.get(18).getHexCityPlayers()).andReturn(cityPlayers);
-
-        EasyMock.replay(mockHexes.get(18));
-
-        BoardHandler b = BoardHandler.createForTesting(mockBoardGraphController, mockHexes, nodeIdToHexes, mockRobber);
-
-        Set<Player> result = b.getPlayersOnHex(18);
-
-        EasyMock.verify(mockHexes.get(18));
-
-        assertEquals(Set.of(mockRedPlayer, mockWhitePlayer), result);
-    }
-
-    // Test Case 35
-    @Test
-    void GetPlayersOnHexEighteen_TwoBlueCities_ReturnBlue_NoDuplicate(){
-        List<Player> settlementPlayers = List.of();
-        List<Player> cityPlayers = List.of(mockBluePlayer, mockBluePlayer);
-
-        EasyMock.expect(mockHexes.get(18).getHexSettlementPlayers()).andReturn(settlementPlayers);
-        EasyMock.expect(mockHexes.get(18).getHexCityPlayers()).andReturn(cityPlayers);
-
-        EasyMock.replay(mockHexes.get(18));
-
-        BoardHandler b = BoardHandler.createForTesting(mockBoardGraphController, mockHexes, nodeIdToHexes, mockRobber);
-
-        Set<Player> result = b.getPlayersOnHex(18);
-
-        EasyMock.verify(mockHexes.get(18));
-
-        assertEquals(Set.of(mockBluePlayer), result);
-    }
-
-    // Test Case 36
-    @Test
-    void GetPlayersOnHexEighteen_ThreeOrangeSettlements_ReturnOrange_NoDuplicate(){
-        List<Player> settlementPlayers = List.of(mockOrangePlayer, mockOrangePlayer, mockOrangePlayer);
-        List<Player> cityPlayers = List.of();
-
-        EasyMock.expect(mockHexes.get(18).getHexSettlementPlayers()).andReturn(settlementPlayers);
-        EasyMock.expect(mockHexes.get(18).getHexCityPlayers()).andReturn(cityPlayers);
-
-        EasyMock.replay(mockHexes.get(18));
-
-        BoardHandler b = BoardHandler.createForTesting(mockBoardGraphController, mockHexes, nodeIdToHexes, mockRobber);
-
-        Set<Player> result = b.getPlayersOnHex(18);
-
-        EasyMock.verify(mockHexes.get(18));
-
-        assertEquals(Set.of(mockOrangePlayer), result);
-    }
-
-    // Test Case 37
-    @Test
-    void GetPlayersOnHexEighteen_ThreeRedCities_ReturnRed_NoDuplicate(){
-        List<Player> settlementPlayers = List.of();
-        List<Player> cityPlayers = List.of(mockRedPlayer, mockRedPlayer, mockRedPlayer);
-
-        EasyMock.expect(mockHexes.get(18).getHexSettlementPlayers()).andReturn(settlementPlayers);
-        EasyMock.expect(mockHexes.get(18).getHexCityPlayers()).andReturn(cityPlayers);
-
-        EasyMock.replay(mockHexes.get(18));
-
-        BoardHandler b = BoardHandler.createForTesting(mockBoardGraphController, mockHexes, nodeIdToHexes, mockRobber);
-
-        Set<Player> result = b.getPlayersOnHex(18);
-
-        EasyMock.verify(mockHexes.get(18));
-
-        assertEquals(Set.of(mockRedPlayer), result);
-    }
-
-    // Test Case 38
-    @Test
-    void GetPlayersOnHexEighteen_NoBuildings_ReturnSetup(){
-        List<Player> settlementPlayers = List.of();
-        List<Player> cityPlayers = List.of();
-
-        EasyMock.expect(mockHexes.get(18).getHexSettlementPlayers()).andReturn(settlementPlayers);
-        EasyMock.expect(mockHexes.get(18).getHexCityPlayers()).andReturn(cityPlayers);
-
-        EasyMock.replay(mockHexes.get(18));
-
-        BoardHandler b = BoardHandler.createForTesting(mockBoardGraphController, mockHexes, nodeIdToHexes, mockRobber);
-
-        Set<Player> result = b.getPlayersOnHex(18);
-
-        EasyMock.verify(mockHexes.get(18));
-
-        assertEquals(Set.of(), result);
-    }
-
-    // Test Case 39
-    @Test
-    void GetPlayersOnHexNegativeOne_ThrowError(){
-        BoardHandler b = BoardHandler.createForTesting(mockBoardGraphController, mockHexes, nodeIdToHexes, mockRobber);
-
-        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
-            b.getPlayersOnHex(-1);
-        });
-
-        String expectedMessage = "Invalid Hex ID, must be within [0,18]";
-        String actualMessage = exception.getMessage();
-        assertEquals(expectedMessage, actualMessage);
-    }
-
-    // Test Case 40
-    @Test
-    void GetPlayersOnHexNineteen_ThrowError(){
-        BoardHandler b = BoardHandler.createForTesting(mockBoardGraphController, mockHexes, nodeIdToHexes, mockRobber);
-
-        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
-            b.getPlayersOnHex(19);
-        });
-
-        String expectedMessage = "Invalid Hex ID, must be within [0,18]";
-        String actualMessage = exception.getMessage();
-        assertEquals(expectedMessage, actualMessage);
-    }
-
-    // Test Case 41
-    @Test
-    void getHexCount_standardBoard_returnsNineteen() {
-        BoardHandler b = new BoardHandler();
-        assertEquals(19, b.getHexCount());
-    }
-
-    // Test Case 42
-    @Test
-    void getHexOrder_standardBoard_returnsNonNull() {
-        BoardHandler b = new BoardHandler();
-        assertNotNull(b.getHexOrder());
-    }
-
-    // Test Case 43
-    @Test
-    void getHexOrder_standardBoard_sizeMatchesGetHexCount() {
-        BoardHandler b = new BoardHandler();
-        assertEquals(b.getHexCount(), b.getHexOrder().size());
-    }
-
-    // Test Case 44
-    @Test
-    void getHexOrder_standardBoard_matchesInitHexesOrder() {
-        BoardHandler b = new BoardHandler();
-        List<String> expected = List.of(
-                Resource.ORE.name(),
-                Resource.WOOL.name(),
-                Resource.LUMBER.name(),
-                Resource.GRAIN.name(),
-                Resource.BRICK.name(),
-                Resource.WOOL.name(),
-                Resource.BRICK.name(),
-                Resource.GRAIN.name(),
-                Resource.LUMBER.name(),
-                Resource.DESERT.name(),
-                Resource.LUMBER.name(),
-                Resource.ORE.name(),
-                Resource.LUMBER.name(),
-                Resource.ORE.name(),
-                Resource.GRAIN.name(),
-                Resource.WOOL.name(),
-                Resource.BRICK.name(),
-                Resource.GRAIN.name(),
-                Resource.LUMBER.name()
-        );
-        assertEquals(expected, b.getHexOrder());
-    }
-
-    // Test Case 45
-    @Test
-    void getHexOrder_mutatingReturnedList_doesNotAffectSubsequentCall() {
-        BoardHandler b = new BoardHandler();
-        List<String> first = b.getHexOrder();
-        first.add("EXTRA");
-        List<String> second = b.getHexOrder();
-        assertEquals(19, second.size());
+    void addRoad_alreadyClaimedEdge_throwsIllegalEdgeClaim() {
+        BoardGraph mockGraph = EasyMock.createMock(BoardGraph.class);
+        Player player = EasyMock.createMock(Player.class);
+        EasyMock.expect(player.getColor()).andReturn(PlayerColor.RED);
+        EasyMock.expect(mockGraph.checkEdgeOccupied(0, 3)).andReturn(true);
+        EasyMock.replay(mockGraph, player);
+
+        BoardHandler board = boardForRoad(mockGraph);
+        assertThrows(IllegalEdgeClaim.class, () -> board.addRoad(player, 0, 3));
+
+        EasyMock.verify(mockGraph, player);
     }
 }

--- a/src/test/java/domain/model/board/BoardHandlerTest.java
+++ b/src/test/java/domain/model/board/BoardHandlerTest.java
@@ -1,107 +1,975 @@
 package domain.model.board;
 
-import domain.model.exceptions.IllegalRoadPlacementException;
-import domain.model.exceptions.IllegalSettlementPlacementException;
+import domain.model.game_pieces.Robber;
+import domain.model.player.Player;
 import domain.model.player.PlayerColor;
+import org.easymock.EasyMock;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static domain.model.board.BoardHandler.initNodeHexMap;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class BoardHandlerTest {
 
-    private BoardHandler boardHandler;
+    private BoardGraphController mockBoardGraphController;
+    private Player mockRedPlayer;
+    private Player mockBluePlayer;
+    private Player mockWhitePlayer;
+    private Player mockOrangePlayer;
+    private List<Hex> mockHexes;
+    private Map<Integer, List<Integer>> nodeIdToHexes;
+    private Robber mockRobber;
 
     @BeforeEach
     void setUp() {
-        boardHandler = new BoardHandler();
+        mockBoardGraphController = EasyMock.createMock(BoardGraphController.class);
+
+        mockRedPlayer = EasyMock.createMock(Player.class);
+        mockBluePlayer = EasyMock.createMock(Player.class);
+        mockWhitePlayer = EasyMock.createMock(Player.class);
+        mockOrangePlayer = EasyMock.createMock(Player.class);
+
+        mockHexes = new ArrayList<>();
+        for (int i = 0; i < 19; i++) {
+            mockHexes.add(EasyMock.createMock(Hex.class));
+        }
+
+        nodeIdToHexes = initNodeHexMap();
+
+        mockRobber = EasyMock.createMock(Robber.class);
     }
 
-    // settlement ownership
-
+    // Test Case 1
     @Test
-    void buildSettlement_unclaimedNode_claimsNodeForPlayer() {
-        boardHandler.buildSettlement(PlayerColor.RED, 7);
-        assertEquals(PlayerColor.RED, boardHandler.getNodeOwner(7));
+    void RedClaimsNodeZero_AndSucceeds(){
+        EasyMock.expect(mockRedPlayer.getColor()).andReturn(PlayerColor.RED);
+
+        PlayerColor expectedColor = PlayerColor.RED;
+
+        mockBoardGraphController.playerClaimStoredNode(expectedColor, 0);
+        EasyMock.expectLastCall();
+
+        mockHexes.get(0).addPlayerSettlementToHex(mockRedPlayer);
+        EasyMock.expectLastCall();
+
+        EasyMock.replay(mockBoardGraphController, mockRedPlayer, mockHexes.get(0));
+
+        BoardHandler b = BoardHandler.createForTesting(mockBoardGraphController, mockHexes, nodeIdToHexes, mockRobber);
+
+        b.buildSettlement(mockRedPlayer, 0);
+
+        EasyMock.verify(mockBoardGraphController, mockRedPlayer, mockHexes.get(0));
+
+        assertTrue(b.checkPlayerOwnsNode(expectedColor, 0));
+
+        int expected = 1;
+        int actual = b.getNodeBuildingLevel(0);
+        assertEquals(expected, actual);
     }
 
+    // Test Case 2
     @Test
-    void buildSettlement_alreadyClaimedNode_throwsIllegalSettlementPlacement() {
-        boardHandler.buildSettlement(PlayerColor.RED, 7);
-        assertThrows(IllegalSettlementPlacementException.class,
-                () -> boardHandler.buildSettlement(PlayerColor.BLUE, 7));
+    void BlueClaimsNodeFiftyThree_AndSucceeds(){
+        EasyMock.expect(mockBluePlayer.getColor()).andReturn(PlayerColor.BLUE);
+
+        PlayerColor expectedColor = PlayerColor.BLUE;
+
+        mockBoardGraphController.playerClaimStoredNode(expectedColor, 53);
+        EasyMock.expectLastCall();
+
+        mockHexes.get(18).addPlayerSettlementToHex(mockBluePlayer);
+        EasyMock.expectLastCall();
+
+        EasyMock.replay(mockBoardGraphController, mockBluePlayer, mockHexes.get(18));
+
+        BoardHandler b = BoardHandler.createForTesting(mockBoardGraphController, mockHexes, nodeIdToHexes, mockRobber);
+
+        b.buildSettlement(mockBluePlayer, 53);
+
+        EasyMock.verify(mockBoardGraphController, mockBluePlayer, mockHexes.get(18));
+
+        assertTrue(b.checkPlayerOwnsNode(expectedColor, 53));
+
+        int expected = 1;
+        int actual = b.getNodeBuildingLevel(53);
+        assertEquals(expected, actual);
     }
 
-    // BVA: settlement node id out of range
-
+    // Test Case 3
     @Test
-    void buildSettlement_nodeIdNegativeOne_throws() {
-        assertThrows(IllegalSettlementPlacementException.class,
-                () -> boardHandler.buildSettlement(PlayerColor.RED, -1));
+    void OrangeClaimsNodeNegativeOne_ReturnsError(){
+        BoardHandler b = BoardHandler.createForTesting(mockBoardGraphController, mockHexes, nodeIdToHexes, mockRobber);
+
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+            b.buildSettlement(mockOrangePlayer, -1);
+        });
+
+        String expectedMessage = "Invalid NodeID - must be within [0, 53].";
+        String actualMessage = exception.getMessage();
+        assertEquals(expectedMessage, actualMessage);
     }
 
+    // Test Case 4
     @Test
-    void buildSettlement_nodeIdFiftyFour_throws() {
-        assertThrows(IllegalSettlementPlacementException.class,
-                () -> boardHandler.buildSettlement(PlayerColor.RED, 54));
+    void WhiteClaimsNodeFiftyFour_ReturnsError(){
+        BoardHandler b = BoardHandler.createForTesting(mockBoardGraphController, mockHexes, nodeIdToHexes, mockRobber);
+
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+            b.buildSettlement(mockWhitePlayer, 54);
+        });
+
+        String expectedMessage = "Invalid NodeID - must be within [0, 53].";
+        String actualMessage = exception.getMessage();
+        assertEquals(expectedMessage, actualMessage);
     }
 
-    // BVA: settlement node id at valid boundaries
-
+    // Test Case 5
     @Test
-    void buildSettlement_nodeIdZero_claimsNode() {
-        boardHandler.buildSettlement(PlayerColor.ORANGE, 0);
-        assertEquals(PlayerColor.ORANGE, boardHandler.getNodeOwner(0));
+    void OrangeClaimsNodeEight_HexesZeroOneFourUpdated(){
+        EasyMock.expect(mockOrangePlayer.getColor()).andReturn(PlayerColor.ORANGE);
+
+        PlayerColor expectedColor = PlayerColor.ORANGE;
+
+        mockBoardGraphController.playerClaimStoredNode(expectedColor, 8);
+        EasyMock.expectLastCall();
+
+        mockHexes.get(0).addPlayerSettlementToHex(mockOrangePlayer);
+        EasyMock.expectLastCall();
+        mockHexes.get(1).addPlayerSettlementToHex(mockOrangePlayer);
+        EasyMock.expectLastCall();
+        mockHexes.get(4).addPlayerSettlementToHex(mockOrangePlayer);
+        EasyMock.expectLastCall();
+
+        EasyMock.replay(mockBoardGraphController, mockOrangePlayer, mockHexes.get(0), mockHexes.get(1), mockHexes.get(4));
+
+        BoardHandler b = BoardHandler.createForTesting(mockBoardGraphController, mockHexes, nodeIdToHexes, mockRobber);
+
+        b.buildSettlement(mockOrangePlayer, 8);
+
+        EasyMock.verify(mockBoardGraphController, mockOrangePlayer, mockHexes.get(0), mockHexes.get(1), mockHexes.get(4));
+
+        assertTrue(b.checkPlayerOwnsNode(expectedColor, 8));
+
+        int expected = 1;
+        int actual = b.getNodeBuildingLevel(8);
+        assertEquals(expected, actual);
     }
 
+    // Test Case 6
     @Test
-    void buildSettlement_nodeIdFiftyThree_claimsNode() {
-        boardHandler.buildSettlement(PlayerColor.BLUE, 53);
-        assertEquals(PlayerColor.BLUE, boardHandler.getNodeOwner(53));
+    void BlueClaimsNodeFour_HexesZeroOneUpdated(){
+        EasyMock.expect(mockBluePlayer.getColor()).andReturn(PlayerColor.BLUE);
+
+        PlayerColor expectedColor = PlayerColor.BLUE;
+
+        mockBoardGraphController.playerClaimStoredNode(expectedColor, 4);
+        EasyMock.expectLastCall();
+
+        mockHexes.get(0).addPlayerSettlementToHex(mockBluePlayer);
+        EasyMock.expectLastCall();
+        mockHexes.get(1).addPlayerSettlementToHex(mockBluePlayer);
+        EasyMock.expectLastCall();
+
+        EasyMock.replay(mockBoardGraphController, mockBluePlayer, mockHexes.get(0), mockHexes.get(1));
+
+        BoardHandler b = BoardHandler.createForTesting(mockBoardGraphController, mockHexes, nodeIdToHexes, mockRobber);
+
+        b.buildSettlement(mockBluePlayer, 4);
+
+        EasyMock.verify(mockBoardGraphController, mockBluePlayer, mockHexes.get(0), mockHexes.get(1));
+
+        assertTrue(b.checkPlayerOwnsNode(expectedColor, 4));
+
+        int expected = 1;
+        int actual = b.getNodeBuildingLevel(4);
+        assertEquals(expected, actual);
+
     }
 
-    // road ownership
-
+    // Test Case 7
     @Test
-    void addRoad_unclaimedEdge_claimsEdgeForPlayer() {
-        boardHandler.addRoad(PlayerColor.RED, 0, 3);
-        assertTrue(boardHandler.isRoadOwnedBy(PlayerColor.RED, 0, 3));
+    void RedBuildsCityOnOwnedNodeZero_HexRemovesSettlement_AddsCity(){
+        EasyMock.expect(mockRedPlayer.getColor()).andReturn(PlayerColor.RED).times(2);
+
+        PlayerColor expectedColor = PlayerColor.RED;
+
+        mockBoardGraphController.playerClaimStoredNode(expectedColor, 0);
+        EasyMock.expectLastCall();
+
+        mockHexes.get(0).addPlayerSettlementToHex(mockRedPlayer);
+        EasyMock.expectLastCall();
+
+        mockHexes.get(0).removePlayerSettlementFromHex(mockRedPlayer);
+        EasyMock.expectLastCall();
+        mockHexes.get(0).addPlayerCityToHex(mockRedPlayer);
+        EasyMock.expectLastCall();
+
+        EasyMock.replay(mockBoardGraphController, mockRedPlayer, mockHexes.get(0));
+
+        BoardHandler b = BoardHandler.createForTesting(mockBoardGraphController, mockHexes, nodeIdToHexes, mockRobber);
+
+        b.buildSettlement(mockRedPlayer, 0);
+
+        b.buildCity(mockRedPlayer, 0);
+
+        EasyMock.verify(mockBoardGraphController, mockRedPlayer, mockHexes.get(0));
+
+        assertTrue(b.checkPlayerOwnsNode(expectedColor, 0));
+
+        int expected = 2;
+        int actual = b.getNodeBuildingLevel(0);
+        assertEquals(expected, actual);
     }
 
+    // Test Case 8
     @Test
-    void addRoad_alreadyClaimedEdge_throwsIllegalRoadPlacement() {
-        boardHandler.addRoad(PlayerColor.RED, 0, 3);
-        assertThrows(IllegalRoadPlacementException.class,
-                () -> boardHandler.addRoad(PlayerColor.BLUE, 0, 3));
+    void BlueBuildsCityOnOwnedNodeFiftyThree_HexRemovesSettlement_AddsCity(){
+        EasyMock.expect(mockBluePlayer.getColor()).andReturn(PlayerColor.BLUE).times(2);
+
+        PlayerColor expectedColor = PlayerColor.BLUE;
+
+        mockBoardGraphController.playerClaimStoredNode(expectedColor, 53);
+        EasyMock.expectLastCall();
+
+        mockHexes.get(18).addPlayerSettlementToHex(mockBluePlayer);
+        EasyMock.expectLastCall();
+
+        mockHexes.get(18).removePlayerSettlementFromHex(mockBluePlayer);
+        EasyMock.expectLastCall();
+        mockHexes.get(18).addPlayerCityToHex(mockBluePlayer);
+        EasyMock.expectLastCall();
+
+        EasyMock.replay(mockBoardGraphController, mockBluePlayer, mockHexes.get(18));
+
+        BoardHandler b = BoardHandler.createForTesting(mockBoardGraphController, mockHexes, nodeIdToHexes, mockRobber);
+
+        b.buildSettlement(mockBluePlayer, 53);
+
+        b.buildCity(mockBluePlayer, 53);
+
+        EasyMock.verify(mockBoardGraphController, mockBluePlayer, mockHexes.get(18));
+
+        assertTrue(b.checkPlayerOwnsNode(expectedColor, 53));
+
+        int expected = 2;
+        int actual = b.getNodeBuildingLevel(53);
+        assertEquals(expected, actual);
     }
 
-    // BVA: edge with identical endpoints
-
+    // Test Case 9
     @Test
-    void addRoad_sameStartAndEnd_throwsIllegalRoadPlacement() {
-        assertThrows(IllegalRoadPlacementException.class,
-                () -> boardHandler.addRoad(PlayerColor.RED, 5, 5));
+    void OrangeBuildsCityOnNodeNegativeOne_ThrowsError(){
+        BoardHandler b = BoardHandler.createForTesting(mockBoardGraphController, mockHexes, nodeIdToHexes, mockRobber);
+
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+            b.buildCity(mockOrangePlayer, -1);
+        });
+
+        String expectedMessage = "Invalid NodeID - must be within [0, 53].";
+        String actualMessage = exception.getMessage();
+        assertEquals(expectedMessage, actualMessage);
     }
 
-    // BVA: edge with reversed ordering (pins startNodeId < endNodeId convention)
-
+    // Test Case 10
     @Test
-    void addRoad_reversedEdgeOrder_throwsIllegalRoadPlacement() {
-        assertThrows(IllegalRoadPlacementException.class,
-                () -> boardHandler.addRoad(PlayerColor.RED, 3, 0));
+    void WhiteBuildsCityOnNodeFiftyFour_ThrowsError(){
+        BoardHandler b = BoardHandler.createForTesting(mockBoardGraphController, mockHexes, nodeIdToHexes, mockRobber);
+
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+            b.buildCity(mockOrangePlayer, 54);
+        });
+
+        String expectedMessage = "Invalid NodeID - must be within [0, 53].";
+        String actualMessage = exception.getMessage();
+        assertEquals(expectedMessage, actualMessage);
     }
 
-    // BVA: road node id out of range
-
+    // Test Case 11
     @Test
-    void addRoad_startNodeIdNegativeOne_throwsIllegalRoadPlacement() {
-        assertThrows(IllegalRoadPlacementException.class,
-                () -> boardHandler.addRoad(PlayerColor.RED, -1, 0));
+    void RedBuildsCityOnNodeSix_BlueOwnsNodeSix_ThrowsError(){
+        EasyMock.expect(mockBluePlayer.getColor()).andReturn(PlayerColor.BLUE);
+        EasyMock.expect(mockRedPlayer.getColor()).andReturn(PlayerColor.RED);
+
+        PlayerColor expectedColor = PlayerColor.BLUE;
+
+        mockBoardGraphController.playerClaimStoredNode(expectedColor, 6);
+        EasyMock.expectLastCall();
+
+        mockHexes.get(2).addPlayerSettlementToHex(mockBluePlayer);
+        EasyMock.expectLastCall();
+
+        EasyMock.replay(mockBoardGraphController, mockBluePlayer, mockHexes.get(2));
+
+        BoardHandler b = BoardHandler.createForTesting(mockBoardGraphController, mockHexes, nodeIdToHexes, mockRobber);
+
+        b.buildSettlement(mockBluePlayer, 6);
+
+        Exception exception = assertThrows(IllegalStateException.class, () -> {
+            b.buildCity(mockRedPlayer, 6);
+        });
+
+        EasyMock.verify(mockBoardGraphController, mockBluePlayer, mockHexes.get(2));
+
+        String expectedMessage = "Node owned by other player, cannot build here.";
+        String actualMessage = exception.getMessage();
+        assertEquals(expectedMessage, actualMessage);
+
+        assertTrue(b.checkPlayerOwnsNode(expectedColor, 6));
     }
 
+    // Test Case 12
     @Test
-    void addRoad_endNodeIdFiftyFour_throwsIllegalRoadPlacement() {
-        assertThrows(IllegalRoadPlacementException.class,
-                () -> boardHandler.addRoad(PlayerColor.RED, 0, 54));
+    void BlueBuildsCity_OnUnclaimedNode_ThrowsError() {
+        EasyMock.expect(mockBluePlayer.getColor()).andReturn(PlayerColor.BLUE);
+
+        EasyMock.replay(mockBluePlayer);
+
+        BoardHandler b = BoardHandler.createForTesting(mockBoardGraphController, mockHexes, nodeIdToHexes, mockRobber);
+
+        Exception exception = assertThrows(IllegalStateException.class, () -> {
+            b.buildCity(mockBluePlayer, 36);
+        });
+
+        String expectedMessage = "Must upgrade a settlement to a city.";
+        String actualMessage = exception.getMessage();
+        assertEquals(expectedMessage, actualMessage);
+
+        EasyMock.verify(mockBluePlayer);
+
+        int expected = 0;
+        int actual = b.getNodeBuildingLevel(36);
+        assertEquals(expected, actual);
+    }
+
+    // Test Case 13
+    @Test
+    void OrangeBuildsCityOnOwnedNodeTwenty_HexRemovesSettlement_AddsCity_Twice(){
+        EasyMock.expect(mockOrangePlayer.getColor()).andReturn(PlayerColor.ORANGE).times(2);
+
+        PlayerColor expectedColor = PlayerColor.ORANGE;
+
+        mockBoardGraphController.playerClaimStoredNode(expectedColor, 20);
+        EasyMock.expectLastCall();
+
+        mockHexes.get(6).addPlayerSettlementToHex(mockOrangePlayer);
+        EasyMock.expectLastCall();
+
+        mockHexes.get(6).removePlayerSettlementFromHex(mockOrangePlayer);
+        EasyMock.expectLastCall();
+        mockHexes.get(6).addPlayerCityToHex(mockOrangePlayer);
+        EasyMock.expectLastCall();
+
+        mockHexes.get(11).addPlayerSettlementToHex(mockOrangePlayer);
+        EasyMock.expectLastCall();
+
+        mockHexes.get(11).removePlayerSettlementFromHex(mockOrangePlayer);
+        EasyMock.expectLastCall();
+        mockHexes.get(11).addPlayerCityToHex(mockOrangePlayer);
+        EasyMock.expectLastCall();
+
+        EasyMock.replay(mockBoardGraphController, mockOrangePlayer, mockHexes.get(6), mockHexes.get(11));
+
+        BoardHandler b = BoardHandler.createForTesting(mockBoardGraphController, mockHexes, nodeIdToHexes, mockRobber);
+
+        b.buildSettlement(mockOrangePlayer, 20);
+
+        b.buildCity(mockOrangePlayer, 20);
+
+        EasyMock.verify(mockBoardGraphController, mockOrangePlayer, mockHexes.get(6), mockHexes.get(11));
+
+        assertTrue(b.checkPlayerOwnsNode(expectedColor, 20));
+
+        int expected = 2;
+        int actual = b.getNodeBuildingLevel(20);
+        assertEquals(expected, actual);
+    }
+
+    // Test Case 14
+    @Test
+    void WhiteBuildsCityOnOwnedNodeTwentyFour_HexRemovesSettlement_AddsCity_ThreeTimes(){
+        EasyMock.expect(mockWhitePlayer.getColor()).andReturn(PlayerColor.WHITE).times(2);
+
+        PlayerColor expectedColor = PlayerColor.WHITE;
+
+        mockBoardGraphController.playerClaimStoredNode(expectedColor, 24);
+        EasyMock.expectLastCall();
+
+        mockHexes.get(5).addPlayerSettlementToHex(mockWhitePlayer);
+        EasyMock.expectLastCall();
+
+        mockHexes.get(5).removePlayerSettlementFromHex(mockWhitePlayer);
+        EasyMock.expectLastCall();
+        mockHexes.get(5).addPlayerCityToHex(mockWhitePlayer);
+        EasyMock.expectLastCall();
+
+        mockHexes.get(9).addPlayerSettlementToHex(mockWhitePlayer);
+        EasyMock.expectLastCall();
+
+        mockHexes.get(9).removePlayerSettlementFromHex(mockWhitePlayer);
+        EasyMock.expectLastCall();
+        mockHexes.get(9).addPlayerCityToHex(mockWhitePlayer);
+        EasyMock.expectLastCall();
+
+        mockHexes.get(10).addPlayerSettlementToHex(mockWhitePlayer);
+        EasyMock.expectLastCall();
+
+        mockHexes.get(10).removePlayerSettlementFromHex(mockWhitePlayer);
+        EasyMock.expectLastCall();
+        mockHexes.get(10).addPlayerCityToHex(mockWhitePlayer);
+        EasyMock.expectLastCall();
+
+        EasyMock.replay(mockBoardGraphController, mockWhitePlayer, mockHexes.get(5), mockHexes.get(9), mockHexes.get(10));
+
+        BoardHandler b = BoardHandler.createForTesting(mockBoardGraphController, mockHexes, nodeIdToHexes, mockRobber);
+
+        b.buildSettlement(mockWhitePlayer, 24);
+
+        b.buildCity(mockWhitePlayer, 24);
+
+        EasyMock.verify(mockBoardGraphController, mockWhitePlayer, mockHexes.get(5), mockHexes.get(9), mockHexes.get(10));
+
+        assertTrue(b.checkPlayerOwnsNode(expectedColor, 24));
+
+        int expected = 2;
+        int actual = b.getNodeBuildingLevel(24);
+        assertEquals(expected, actual);
+    }
+
+    // Test Case 15
+    @Test
+    void RedClaimsEdge_ZeroOne_CallPlayerClaimStoredEdge(){
+        EasyMock.expect(mockRedPlayer.getColor()).andReturn(PlayerColor.RED);
+
+        PlayerColor expectedColor = PlayerColor.RED;
+
+        mockBoardGraphController.playerClaimStoredEdge(expectedColor, 0, 1);
+        EasyMock.expectLastCall();
+
+        EasyMock.replay(mockBoardGraphController, mockRedPlayer);
+
+        BoardHandler b = BoardHandler.createForTesting(mockBoardGraphController, mockHexes, nodeIdToHexes, mockRobber);
+
+        b.addRoad(mockRedPlayer, 0, 1);
+
+        EasyMock.verify(mockBoardGraphController, mockRedPlayer);
+    }
+
+    // Test Case 16
+    @Test
+    void OrangeClaimsEdge_FiftyTwo_FiftyThree_CallPlayerClaimStoredEdge(){
+        EasyMock.expect(mockOrangePlayer.getColor()).andReturn(PlayerColor.ORANGE);
+
+        PlayerColor expectedColor = PlayerColor.ORANGE;
+
+        mockBoardGraphController.playerClaimStoredEdge(expectedColor, 52, 53);
+        EasyMock.expectLastCall();
+
+        EasyMock.replay(mockBoardGraphController, mockOrangePlayer);
+
+        BoardHandler b = BoardHandler.createForTesting(mockBoardGraphController, mockHexes, nodeIdToHexes, mockRobber);
+
+        b.addRoad(mockOrangePlayer, 52, 53);
+
+        EasyMock.verify(mockBoardGraphController, mockOrangePlayer);
+    }
+
+    // Test Case 17
+    @Test
+    void WhiteClaimsEdge_NegativeOne_Zero_ThrowError(){
+        BoardHandler b = BoardHandler.createForTesting(mockBoardGraphController, mockHexes, nodeIdToHexes, mockRobber);
+
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+            b.addRoad(mockWhitePlayer, -1, 0);
+        });
+
+        String expectedMessage = "Edge nodeId out of bounds. Must be within [0, 53].";
+        String actualMessage = exception.getMessage();
+        assertEquals(expectedMessage, actualMessage);
+    }
+
+    // Test Case 18
+    @Test
+    void WhiteClaimsEdge_Zero_NegativeOne_ThrowError(){
+        BoardHandler b = BoardHandler.createForTesting(mockBoardGraphController, mockHexes, nodeIdToHexes, mockRobber);
+
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+            b.addRoad(mockWhitePlayer, 0, -1);
+        });
+
+        String expectedMessage = "Edge nodeId out of bounds. Must be within [0, 53].";
+        String actualMessage = exception.getMessage();
+        assertEquals(expectedMessage, actualMessage);
+    }
+
+    // Test Case 19
+    @Test
+    void BlueClaimsEdge_FiftyThree_FiftyFour_ThrowError(){
+        BoardHandler b = BoardHandler.createForTesting(mockBoardGraphController, mockHexes, nodeIdToHexes, mockRobber);
+
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+            b.addRoad(mockBluePlayer, 53, 54);
+        });
+
+        String expectedMessage = "Edge nodeId out of bounds. Must be within [0, 53].";
+        String actualMessage = exception.getMessage();
+        assertEquals(expectedMessage, actualMessage);
+    }
+
+    // Test Case 20
+    @Test
+    void BlueClaimsEdge_FiftyFour_FiftyThree_ThrowError(){
+        BoardHandler b = BoardHandler.createForTesting(mockBoardGraphController, mockHexes, nodeIdToHexes, mockRobber);
+
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+            b.addRoad(mockBluePlayer, 54, 53);
+        });
+
+        String expectedMessage = "Edge nodeId out of bounds. Must be within [0, 53].";
+        String actualMessage = exception.getMessage();
+        assertEquals(expectedMessage, actualMessage);
+    }
+
+    // Test Case 21
+    @Test
+    void TwoRolled_RobberNotPresent_CallsAwardResources(){
+        for (int i = 0; i < 19; i++) {
+            if (i == 1) {
+                EasyMock.expect(mockHexes.get(i).getHexId()).andReturn(1);
+                EasyMock.expect(mockHexes.get(i).getHexRollNum()).andReturn(2);
+            } else {
+                EasyMock.expect(mockHexes.get(i).getHexId()).andReturn(0);
+                EasyMock.expect(mockHexes.get(i).getHexRollNum()).andReturn(0);
+            }
+        }
+
+        mockHexes.get(1).awardSettlementResources();
+        EasyMock.expectLastCall();
+        mockHexes.get(1).awardCityResources();
+        EasyMock.expectLastCall();
+
+        EasyMock.expect(mockRobber.getRobberLocation()).andReturn(9);
+
+        EasyMock.replay(mockHexes.toArray());
+        EasyMock.replay(mockRobber);
+
+        BoardHandler b = BoardHandler.createForTesting(mockBoardGraphController, mockHexes, nodeIdToHexes, mockRobber);
+
+        b.awardResources(2);
+
+        EasyMock.verify(mockHexes.toArray());
+        EasyMock.verify(mockRobber);
+    }
+
+    // Test Case 22
+    @Test
+    void TwelveRolled_RobberNotPresent_CallsAwardResources(){
+        for (int i = 0; i < 19; i++) {
+            if (i == 3) {
+                EasyMock.expect(mockHexes.get(i).getHexId()).andReturn(3);
+                EasyMock.expect(mockHexes.get(i).getHexRollNum()).andReturn(12);
+            }
+            else {
+                EasyMock.expect(mockHexes.get(i).getHexId()).andReturn(0);
+                EasyMock.expect(mockHexes.get(i).getHexRollNum()).andReturn(0);
+            }
+        }
+
+        mockHexes.get(3).awardSettlementResources();
+        EasyMock.expectLastCall();
+
+        mockHexes.get(3).awardCityResources();
+        EasyMock.expectLastCall();
+
+        EasyMock.expect(mockRobber.getRobberLocation()).andReturn(9);
+
+        EasyMock.replay(mockHexes.toArray());
+        EasyMock.replay(mockRobber);
+
+        BoardHandler b = BoardHandler.createForTesting(mockBoardGraphController, mockHexes, nodeIdToHexes, mockRobber);
+
+        b.awardResources(12);
+
+        EasyMock.verify(mockHexes.toArray());
+        EasyMock.verify(mockRobber);
+    }
+
+    // Test Case 23
+    @Test
+    void EightRolled_RobberNotPresent_CallsAwardResourcesTwice(){
+        for (int i = 0; i < 19; i++) {
+            if (i == 11) {
+                EasyMock.expect(mockHexes.get(i).getHexId()).andReturn(11);
+                EasyMock.expect(mockHexes.get(i).getHexRollNum()).andReturn(8);
+            }
+            else if (i == 12) {
+                EasyMock.expect(mockHexes.get(i).getHexId()).andReturn(12);
+                EasyMock.expect(mockHexes.get(i).getHexRollNum()).andReturn(8);
+            }
+            else {
+                EasyMock.expect(mockHexes.get(i).getHexId()).andReturn(0);
+                EasyMock.expect(mockHexes.get(i).getHexRollNum()).andReturn(0);
+            }
+        }
+
+        mockHexes.get(11).awardSettlementResources();
+        EasyMock.expectLastCall();
+        mockHexes.get(11).awardCityResources();
+        EasyMock.expectLastCall();
+
+        mockHexes.get(12).awardSettlementResources();
+        EasyMock.expectLastCall();
+        mockHexes.get(12).awardCityResources();
+        EasyMock.expectLastCall();
+
+        EasyMock.expect(mockRobber.getRobberLocation()).andReturn(9);
+
+        EasyMock.replay(mockHexes.toArray());
+        EasyMock.replay(mockRobber);
+
+        BoardHandler b = BoardHandler.createForTesting(mockBoardGraphController, mockHexes, nodeIdToHexes, mockRobber);
+
+        b.awardResources(8);
+
+        EasyMock.verify(mockHexes.toArray());
+        EasyMock.verify(mockRobber);
+    }
+
+    // Test Case 24
+    @Test
+    void TwoRolled_RobberIsPresent_NoCallsToAward(){
+        for (int i = 0; i < 19; i++) {
+            if (i == 1) {
+                EasyMock.expect(mockHexes.get(i).getHexId()).andReturn(1);
+                EasyMock.expect(mockHexes.get(i).getHexRollNum()).andReturn(2);
+            }
+            else {
+                EasyMock.expect(mockHexes.get(i).getHexId()).andReturn(0);
+                EasyMock.expect(mockHexes.get(i).getHexRollNum()).andReturn(0);
+            }
+        }
+
+        EasyMock.expect(mockRobber.getRobberLocation()).andReturn(1);
+
+        EasyMock.replay(mockHexes.toArray());
+        EasyMock.replay(mockRobber);
+
+        BoardHandler b = BoardHandler.createForTesting(mockBoardGraphController, mockHexes, nodeIdToHexes, mockRobber);
+
+        b.awardResources(2);
+
+        EasyMock.verify(mockHexes.toArray());
+        EasyMock.verify(mockRobber);
+    }
+
+    // Test Case 25
+    @Test
+    void EightRolled_RobberIsPresent_CallsAwardResourcesOnce(){
+        for (int i = 0; i < 19; i++) {
+            if (i == 11) {
+                EasyMock.expect(mockHexes.get(i).getHexId()).andReturn(11);
+                EasyMock.expect(mockHexes.get(i).getHexRollNum()).andReturn(8);
+            }
+            else if (i == 12) {
+                EasyMock.expect(mockHexes.get(i).getHexId()).andReturn(12);
+                EasyMock.expect(mockHexes.get(i).getHexRollNum()).andReturn(8);
+            }
+            else {
+                EasyMock.expect(mockHexes.get(i).getHexId()).andReturn(0);
+                EasyMock.expect(mockHexes.get(i).getHexRollNum()).andReturn(0);
+            }
+        }
+
+        mockHexes.get(11).awardSettlementResources();
+        EasyMock.expectLastCall();
+        mockHexes.get(11).awardCityResources();
+        EasyMock.expectLastCall();
+
+        EasyMock.expect(mockRobber.getRobberLocation()).andReturn(12);
+
+        EasyMock.replay(mockHexes.toArray());
+        EasyMock.replay(mockRobber);
+
+        BoardHandler b = BoardHandler.createForTesting(mockBoardGraphController, mockHexes, nodeIdToHexes, mockRobber);
+
+        b.awardResources(8);
+
+        EasyMock.verify(mockHexes.toArray());
+        EasyMock.verify(mockRobber);
+    }
+
+    // Test Case 26
+    @Test
+    void MoveRobberLocation_FromHexIdZero_Eighteen(){
+        EasyMock.expect(mockRobber.getRobberLocation()).andReturn(0);
+
+        mockRobber.moveRobber(18);
+        EasyMock.expectLastCall();
+
+        EasyMock.replay(mockRobber);
+
+        BoardHandler b = BoardHandler.createForTesting(mockBoardGraphController, mockHexes, nodeIdToHexes, mockRobber);
+
+        b.moveRobber(18);
+
+        EasyMock.verify(mockRobber);
+    }
+
+    // Test Case 27
+    @Test
+    void MoveRobberLocation_FromHexIdEighteen_ToZero(){
+        EasyMock.expect(mockRobber.getRobberLocation()).andReturn(18);
+
+        mockRobber.moveRobber(0);
+        EasyMock.expectLastCall();
+
+        EasyMock.replay(mockRobber);
+
+        BoardHandler b = BoardHandler.createForTesting(mockBoardGraphController, mockHexes, nodeIdToHexes, mockRobber);
+
+        b.moveRobber(0);
+
+        EasyMock.verify(mockRobber);
+    }
+
+    // Test Case 28
+    @Test
+    void MoveRobberLocation_ToNegativeOne_ThrowError(){
+        BoardHandler b = BoardHandler.createForTesting(mockBoardGraphController, mockHexes, nodeIdToHexes, mockRobber);
+
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+            b.moveRobber(-1);
+        });
+
+        String expectedMessage = "Cannot move Robber to invalid Hex ID";
+        String actualMessage = exception.getMessage();
+        assertEquals(expectedMessage, actualMessage);
+    }
+
+    // Test Case 29
+    @Test
+    void MoveRobberLocation_ToNineteen_ThrowError(){
+        BoardHandler b = BoardHandler.createForTesting(mockBoardGraphController, mockHexes, nodeIdToHexes, mockRobber);
+
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+            b.moveRobber(19);
+        });
+
+        String expectedMessage = "Cannot move Robber to invalid Hex ID";
+        String actualMessage = exception.getMessage();
+        assertEquals(expectedMessage, actualMessage);
+    }
+
+    // Test Case 30
+    @Test
+    void MoveRobberLocation_FromNine_ToNine_ThrowError(){
+        EasyMock.expect(mockRobber.getRobberLocation()).andReturn(9);
+
+        EasyMock.replay(mockRobber);
+
+        BoardHandler b = BoardHandler.createForTesting(mockBoardGraphController, mockHexes, nodeIdToHexes, mockRobber);
+
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+            b.moveRobber(9);
+        });
+
+        String expectedMessage = "Must move robber to new location";
+        String actualMessage = exception.getMessage();
+        assertEquals(expectedMessage, actualMessage);
+
+        EasyMock.verify(mockRobber);
+    }
+
+    // Test Case 31
+    @Test
+    void GetPlayersOnHexZero_JustBlueSettlement_ReturnBlue(){
+        List<Player> settlementPlayers = List.of(mockBluePlayer);
+        List<Player> cityPlayers = List.of();
+
+        EasyMock.expect(mockHexes.get(0).getHexSettlementPlayers()).andReturn(settlementPlayers);
+        EasyMock.expect(mockHexes.get(0).getHexCityPlayers()).andReturn(cityPlayers);
+
+        EasyMock.replay(mockHexes.get(0));
+
+        BoardHandler b = BoardHandler.createForTesting(mockBoardGraphController, mockHexes, nodeIdToHexes, mockRobber);
+
+        Set<Player> result = b.getPlayersOnHex(0);
+
+        EasyMock.verify(mockHexes.get(0));
+
+        assertEquals(Set.of(mockBluePlayer), result);
+    }
+
+    // Test Case 32
+    @Test
+    void GetPlayersOnHexEighteen_JustRedCity_ReturnRed(){
+        List<Player> settlementPlayers = List.of();
+        List<Player> cityPlayers = List.of(mockRedPlayer);
+
+        EasyMock.expect(mockHexes.get(18).getHexSettlementPlayers()).andReturn(settlementPlayers);
+        EasyMock.expect(mockHexes.get(18).getHexCityPlayers()).andReturn(cityPlayers);
+
+        EasyMock.replay(mockHexes.get(18));
+
+        BoardHandler b = BoardHandler.createForTesting(mockBoardGraphController, mockHexes, nodeIdToHexes, mockRobber);
+
+        Set<Player> result = b.getPlayersOnHex(18);
+
+        EasyMock.verify(mockHexes.get(18));
+
+        assertEquals(Set.of(mockRedPlayer), result);
+    }
+
+    // Test Case 33
+    @Test
+    void GetPlayersOnHexEighteen_WhiteOrangeSettlements_RedCity_ReturnWhiteOrangeRed(){
+        List<Player> settlementPlayers = List.of(mockWhitePlayer, mockOrangePlayer);
+        List<Player> cityPlayers = List.of(mockRedPlayer);
+
+        EasyMock.expect(mockHexes.get(18).getHexSettlementPlayers()).andReturn(settlementPlayers);
+        EasyMock.expect(mockHexes.get(18).getHexCityPlayers()).andReturn(cityPlayers);
+
+        EasyMock.replay(mockHexes.get(18));
+
+        BoardHandler b = BoardHandler.createForTesting(mockBoardGraphController, mockHexes, nodeIdToHexes, mockRobber);
+
+        Set<Player> result = b.getPlayersOnHex(18);
+
+        EasyMock.verify(mockHexes.get(18));
+
+        assertEquals(Set.of(mockRedPlayer, mockWhitePlayer, mockOrangePlayer), result);
+    }
+
+    // Test Case 34
+    @Test
+    void GetPlayersOnHexEighteen_TwoWhiteSettlements_RedCity_ReturnWhiteRed_NoDuplicate(){
+        List<Player> settlementPlayers = List.of(mockWhitePlayer, mockWhitePlayer);
+        List<Player> cityPlayers = List.of(mockRedPlayer);
+
+        EasyMock.expect(mockHexes.get(18).getHexSettlementPlayers()).andReturn(settlementPlayers);
+        EasyMock.expect(mockHexes.get(18).getHexCityPlayers()).andReturn(cityPlayers);
+
+        EasyMock.replay(mockHexes.get(18));
+
+        BoardHandler b = BoardHandler.createForTesting(mockBoardGraphController, mockHexes, nodeIdToHexes, mockRobber);
+
+        Set<Player> result = b.getPlayersOnHex(18);
+
+        EasyMock.verify(mockHexes.get(18));
+
+        assertEquals(Set.of(mockRedPlayer, mockWhitePlayer), result);
+    }
+
+    // Test Case 35
+    @Test
+    void GetPlayersOnHexEighteen_TwoBlueCities_ReturnBlue_NoDuplicate(){
+        List<Player> settlementPlayers = List.of();
+        List<Player> cityPlayers = List.of(mockBluePlayer, mockBluePlayer);
+
+        EasyMock.expect(mockHexes.get(18).getHexSettlementPlayers()).andReturn(settlementPlayers);
+        EasyMock.expect(mockHexes.get(18).getHexCityPlayers()).andReturn(cityPlayers);
+
+        EasyMock.replay(mockHexes.get(18));
+
+        BoardHandler b = BoardHandler.createForTesting(mockBoardGraphController, mockHexes, nodeIdToHexes, mockRobber);
+
+        Set<Player> result = b.getPlayersOnHex(18);
+
+        EasyMock.verify(mockHexes.get(18));
+
+        assertEquals(Set.of(mockBluePlayer), result);
+    }
+
+    // Test Case 36
+    @Test
+    void GetPlayersOnHexEighteen_ThreeOrangeSettlements_ReturnOrange_NoDuplicate(){
+        List<Player> settlementPlayers = List.of(mockOrangePlayer, mockOrangePlayer, mockOrangePlayer);
+        List<Player> cityPlayers = List.of();
+
+        EasyMock.expect(mockHexes.get(18).getHexSettlementPlayers()).andReturn(settlementPlayers);
+        EasyMock.expect(mockHexes.get(18).getHexCityPlayers()).andReturn(cityPlayers);
+
+        EasyMock.replay(mockHexes.get(18));
+
+        BoardHandler b = BoardHandler.createForTesting(mockBoardGraphController, mockHexes, nodeIdToHexes, mockRobber);
+
+        Set<Player> result = b.getPlayersOnHex(18);
+
+        EasyMock.verify(mockHexes.get(18));
+
+        assertEquals(Set.of(mockOrangePlayer), result);
+    }
+
+    // Test Case 37
+    @Test
+    void GetPlayersOnHexEighteen_ThreeRedCities_ReturnRed_NoDuplicate(){
+        List<Player> settlementPlayers = List.of();
+        List<Player> cityPlayers = List.of(mockRedPlayer, mockRedPlayer, mockRedPlayer);
+
+        EasyMock.expect(mockHexes.get(18).getHexSettlementPlayers()).andReturn(settlementPlayers);
+        EasyMock.expect(mockHexes.get(18).getHexCityPlayers()).andReturn(cityPlayers);
+
+        EasyMock.replay(mockHexes.get(18));
+
+        BoardHandler b = BoardHandler.createForTesting(mockBoardGraphController, mockHexes, nodeIdToHexes, mockRobber);
+
+        Set<Player> result = b.getPlayersOnHex(18);
+
+        EasyMock.verify(mockHexes.get(18));
+
+        assertEquals(Set.of(mockRedPlayer), result);
+    }
+
+    // Test Case 38
+    @Test
+    void GetPlayersOnHexEighteen_NoBuildings_ReturnSetup(){
+        List<Player> settlementPlayers = List.of();
+        List<Player> cityPlayers = List.of();
+
+        EasyMock.expect(mockHexes.get(18).getHexSettlementPlayers()).andReturn(settlementPlayers);
+        EasyMock.expect(mockHexes.get(18).getHexCityPlayers()).andReturn(cityPlayers);
+
+        EasyMock.replay(mockHexes.get(18));
+
+        BoardHandler b = BoardHandler.createForTesting(mockBoardGraphController, mockHexes, nodeIdToHexes, mockRobber);
+
+        Set<Player> result = b.getPlayersOnHex(18);
+
+        EasyMock.verify(mockHexes.get(18));
+
+        assertEquals(Set.of(), result);
+    }
+
+    // Test Case 39
+    @Test
+    void GetPlayersOnHexNegativeOne_ThrowError(){
+        BoardHandler b = BoardHandler.createForTesting(mockBoardGraphController, mockHexes, nodeIdToHexes, mockRobber);
+
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+            b.getPlayersOnHex(-1);
+        });
+
+        String expectedMessage = "Invalid Hex ID, must be within [0,18]";
+        String actualMessage = exception.getMessage();
+        assertEquals(expectedMessage, actualMessage);
+    }
+
+    // Test Case 40
+    @Test
+    void GetPlayersOnHexNineteen_ThrowError(){
+        BoardHandler b = BoardHandler.createForTesting(mockBoardGraphController, mockHexes, nodeIdToHexes, mockRobber);
+
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+            b.getPlayersOnHex(19);
+        });
+
+        String expectedMessage = "Invalid Hex ID, must be within [0,18]";
+        String actualMessage = exception.getMessage();
+        assertEquals(expectedMessage, actualMessage);
     }
 }

--- a/src/test/java/domain/model/board/BoardHandlerTest.java
+++ b/src/test/java/domain/model/board/BoardHandlerTest.java
@@ -3,6 +3,7 @@ package domain.model.board;
 import domain.model.game_pieces.Robber;
 import domain.model.player.Player;
 import domain.model.player.PlayerColor;
+import domain.model.resources.Resource;
 import org.easymock.EasyMock;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -971,5 +972,64 @@ public class BoardHandlerTest {
         String expectedMessage = "Invalid Hex ID, must be within [0,18]";
         String actualMessage = exception.getMessage();
         assertEquals(expectedMessage, actualMessage);
+    }
+
+    // Test Case 41
+    @Test
+    void getHexCount_standardBoard_returnsNineteen() {
+        BoardHandler b = new BoardHandler();
+        assertEquals(19, b.getHexCount());
+    }
+
+    // Test Case 42
+    @Test
+    void getHexOrder_standardBoard_returnsNonNull() {
+        BoardHandler b = new BoardHandler();
+        assertNotNull(b.getHexOrder());
+    }
+
+    // Test Case 43
+    @Test
+    void getHexOrder_standardBoard_sizeMatchesGetHexCount() {
+        BoardHandler b = new BoardHandler();
+        assertEquals(b.getHexCount(), b.getHexOrder().size());
+    }
+
+    // Test Case 44
+    @Test
+    void getHexOrder_standardBoard_matchesInitHexesOrder() {
+        BoardHandler b = new BoardHandler();
+        List<String> expected = List.of(
+                Resource.ORE.name(),
+                Resource.WOOL.name(),
+                Resource.LUMBER.name(),
+                Resource.GRAIN.name(),
+                Resource.BRICK.name(),
+                Resource.WOOL.name(),
+                Resource.BRICK.name(),
+                Resource.GRAIN.name(),
+                Resource.LUMBER.name(),
+                Resource.DESERT.name(),
+                Resource.LUMBER.name(),
+                Resource.ORE.name(),
+                Resource.LUMBER.name(),
+                Resource.ORE.name(),
+                Resource.GRAIN.name(),
+                Resource.WOOL.name(),
+                Resource.BRICK.name(),
+                Resource.GRAIN.name(),
+                Resource.LUMBER.name()
+        );
+        assertEquals(expected, b.getHexOrder());
+    }
+
+    // Test Case 45
+    @Test
+    void getHexOrder_mutatingReturnedList_doesNotAffectSubsequentCall() {
+        BoardHandler b = new BoardHandler();
+        List<String> first = b.getHexOrder();
+        first.add("EXTRA");
+        List<String> second = b.getHexOrder();
+        assertEquals(19, second.size());
     }
 }


### PR DESCRIPTION
Ports Kevin's BoardHandler work from wip-board-handler into the current domain.model.* package structure.

Key changes:
- Replaces stub BoardHandler with real Player-based board placement API
- Ports settlement, road, city, robber, hex list, node-to-hex mapping, and hex summary behavior
- Updates GameModel build call sites to pass getCurrentPlayer()
- Replaces stub BoardHandler tests with adapted BVA tests
- Adds tests for getHexCount() and getHexOrder()
- Preserves current architecture; does not merge flat domain.* package structure

Tests run:
- ./gradlew test --tests "domain.model.board.BoardHandlerTest" -x pitest
- ./gradlew test --tests "ui.controller.GameSetupControllerTest" -x pitest
- ./gradlew test -x pitest